### PR TITLE
add a workaround until delta version is upgraded to include record count

### DIFF
--- a/core/src/test/java/io/onetable/GenericTable.java
+++ b/core/src/test/java/io/onetable/GenericTable.java
@@ -56,6 +56,8 @@ public interface GenericTable<T, Q> extends AutoCloseable {
 
   List<String> getColumnsToSelect();
 
+  String getFilterQuery();
+
   static GenericTable getInstance(
       String tableName,
       Path tempDir,

--- a/core/src/test/java/io/onetable/ITOneTableClient.java
+++ b/core/src/test/java/io/onetable/ITOneTableClient.java
@@ -126,7 +126,7 @@ public class ITOneTableClient {
 
   private static Stream<Arguments> generateTestParametersForFormatsSyncModesAndPartitioning() {
     List<Arguments> arguments = new ArrayList<>();
-    for (TableFormat sourceTableFormat : Arrays.asList(TableFormat.HUDI, TableFormat.DELTA)) {
+    for (TableFormat sourceTableFormat : Arrays.asList(TableFormat.DELTA)) {
       for (SyncMode syncMode : SyncMode.values()) {
         for (boolean isPartitioned : new boolean[] {true, false}) {
           arguments.add(Arguments.of(sourceTableFormat, syncMode, isPartitioned));
@@ -203,6 +203,8 @@ public class ITOneTableClient {
       table.deleteRows(insertRecords.subList(30, 50));
       oneTableClient.sync(perTableConfig, sourceClientProvider);
       checkDatasetEquivalence(sourceTableFormat, table, targetTableFormats, 180);
+      checkDatasetEquivalenceWithFilter(
+          sourceTableFormat, table, targetTableFormats, table.getFilterQuery());
     }
 
     try (GenericTable tableWithUpdatedSchema =

--- a/core/src/test/java/io/onetable/ITOneTableClient.java
+++ b/core/src/test/java/io/onetable/ITOneTableClient.java
@@ -126,7 +126,7 @@ public class ITOneTableClient {
 
   private static Stream<Arguments> generateTestParametersForFormatsSyncModesAndPartitioning() {
     List<Arguments> arguments = new ArrayList<>();
-    for (TableFormat sourceTableFormat : Arrays.asList(TableFormat.DELTA)) {
+    for (TableFormat sourceTableFormat : Arrays.asList(TableFormat.HUDI, TableFormat.DELTA)) {
       for (SyncMode syncMode : SyncMode.values()) {
         for (boolean isPartitioned : new boolean[] {true, false}) {
           arguments.add(Arguments.of(sourceTableFormat, syncMode, isPartitioned));

--- a/core/src/test/java/io/onetable/TestAbstractHudiTable.java
+++ b/core/src/test/java/io/onetable/TestAbstractHudiTable.java
@@ -755,6 +755,11 @@ public abstract class TestAbstractHudiTable
   }
 
   @Override
+  public String getFilterQuery() {
+    return String.format("%s > aaa", RECORD_KEY_FIELD_NAME);
+  }
+
+  @Override
   public String getOrderByColumn() {
     return "_hoodie_record_key";
   }

--- a/core/src/test/java/io/onetable/TestAbstractHudiTable.java
+++ b/core/src/test/java/io/onetable/TestAbstractHudiTable.java
@@ -756,7 +756,7 @@ public abstract class TestAbstractHudiTable
 
   @Override
   public String getFilterQuery() {
-    return String.format("%s > aaa", RECORD_KEY_FIELD_NAME);
+    return String.format("%s > 'aaa'", RECORD_KEY_FIELD_NAME);
   }
 
   @Override

--- a/core/src/test/java/io/onetable/TestSparkDeltaTable.java
+++ b/core/src/test/java/io/onetable/TestSparkDeltaTable.java
@@ -168,6 +168,11 @@ public class TestSparkDeltaTable implements GenericTable<Row, Object>, Closeable
     }
   }
 
+  @Override
+  public String getFilterQuery() {
+    return "id < 25";
+  }
+
   public void runCompaction() {
     deltaTable.optimize().executeCompaction();
   }

--- a/core/src/test/java/io/onetable/TestSparkDeltaTable.java
+++ b/core/src/test/java/io/onetable/TestSparkDeltaTable.java
@@ -170,7 +170,7 @@ public class TestSparkDeltaTable implements GenericTable<Row, Object>, Closeable
 
   @Override
   public String getFilterQuery() {
-    return "id < 25";
+    return "id % 2 = 0";
   }
 
   public void runCompaction() {

--- a/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
+++ b/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
@@ -72,7 +72,6 @@ import io.onetable.model.storage.FileFormat;
 import io.onetable.model.storage.OneDataFile;
 import io.onetable.model.storage.OneFileGroup;
 import io.onetable.model.storage.TableFormat;
-import io.onetable.testutil.Issues;
 
 public class ITDeltaSourceClient {
 
@@ -682,9 +681,7 @@ public class ITDeltaSourceClient {
     Assertions.assertEquals(expected.getPartitionValues(), actual.getPartitionValues());
     Assertions.assertEquals(expected.getPartitionPath(), actual.getPartitionPath());
     Assertions.assertEquals(expected.getFileSizeBytes(), actual.getFileSizeBytes());
-    if (Issues.ISSUE_102_FIXED) {
-      Assertions.assertEquals(expected.getRecordCount(), actual.getRecordCount());
-    }
+    Assertions.assertEquals(expected.getRecordCount(), actual.getRecordCount());
     Instant now = Instant.now();
     long minRange = now.minus(1, ChronoUnit.HOURS).toEpochMilli();
     long maxRange = now.toEpochMilli();


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

#102 highlights that we do not properly set the record count when Delta is the source. Until we upgrade, we can simply get the count from the column level stats for the file.

## Brief change log

- Use column stats for count

## Verify this pull request

- Added integration test that performs filter, this is how the regression was discovered
- Updates unit test check
