### PR TITLE
Refactor OneTableClient in preparation for iterative table changes fetching

### DIFF
--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -21,7 +21,6 @@ package io.onetable.spi.sync;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 

--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -94,15 +94,8 @@ public class TableFormatSync {
     return results;
   }
 
-  public Optional<Instant> getLastSyncInstant() {
-    return client.getTableMetadata().map(OneTableMetadata::getLastInstantSynced);
-  }
-
-  public List<Instant> getPendingInstantsToConsiderForNextSync() {
-    return client
-        .getTableMetadata()
-        .map(OneTableMetadata::getInstantsToConsiderForNextSync)
-        .orElse(Collections.emptyList());
+  public Optional<OneTableMetadata> getTableMetadata() {
+    return client.getTableMetadata();
   }
 
   private SyncResult getSyncResult(

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -43,6 +43,7 @@ import io.onetable.model.IncrementalTableChanges;
 import io.onetable.model.InstantsForIncrementalSync;
 import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
+import io.onetable.model.OneTableMetadata;
 import io.onetable.model.TableChange;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
@@ -103,8 +104,14 @@ public class OneTableClient {
                     Function.identity(),
                     tableFormat ->
                         tableFormatClientFactory.createForFormat(tableFormat, config, conf)));
+    // State for each TableFormat
+    Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat =
+        syncClientByFormat.entrySet().stream()
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getTableMetadata()));
     Map<TableFormat, TableFormatSync> formatsToSyncIncrementally =
-        getFormatsToSyncIncrementally(config, syncClientByFormat, source.getSourceClient());
+        getFormatsToSyncIncrementally(
+            config, syncClientByFormat, lastSyncMetadataByFormat, source.getSourceClient());
     Map<TableFormat, TableFormatSync> formatsToSyncBySnapshot =
         syncClientByFormat.entrySet().stream()
             .filter(entry -> !formatsToSyncIncrementally.containsKey(entry.getKey()))
@@ -116,7 +123,7 @@ public class OneTableClient {
     SyncResultForTableFormats syncResultForIncrementalSync =
         formatsToSyncIncrementally.isEmpty()
             ? SyncResultForTableFormats.builder().build()
-            : syncIncrementalChanges(formatsToSyncIncrementally, source);
+            : syncIncrementalChanges(formatsToSyncIncrementally, lastSyncMetadataByFormat, source);
     log.info(
         "OneTable Sync is successful for the following formats " + config.getTargetTableFormats());
     Map<TableFormat, SyncResult> syncResultsMerged =
@@ -128,28 +135,24 @@ public class OneTableClient {
   private <COMMIT> Map<TableFormat, TableFormatSync> getFormatsToSyncIncrementally(
       PerTableConfig perTableConfig,
       Map<TableFormat, TableFormatSync> syncClientByFormat,
+      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
       SourceClient<COMMIT> sourceClient) {
     if (perTableConfig.getSyncMode() == SyncMode.FULL) {
       // Full sync requested by config, hence no incremental sync.
       return Collections.emptyMap();
     }
-    Map<TableFormat, Optional<Instant>> lastSyncInstantByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey, entry -> entry.getValue().getLastSyncInstant()));
-    Map<TableFormat, List<Instant>> pendingInstantsToConsiderForNextSyncByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> entry.getValue().getPendingInstantsToConsiderForNextSync()));
     return syncClientByFormat.entrySet().stream()
         .filter(
             entry -> {
-              Optional<Instant> lastSyncInstant = lastSyncInstantByFormat.get(entry.getKey());
+              Optional<Instant> lastSyncInstant =
+                  lastSyncMetadataByFormat
+                      .get(entry.getKey())
+                      .map(OneTableMetadata::getLastInstantSynced);
               List<Instant> pendingInstants =
-                  pendingInstantsToConsiderForNextSyncByFormat.get(entry.getKey());
+                  lastSyncMetadataByFormat
+                      .get(entry.getKey())
+                      .map(OneTableMetadata::getInstantsToConsiderForNextSync)
+                      .orElse(Collections.emptyList());
               return isIncrementalSyncSufficient(sourceClient, lastSyncInstant, pendingInstants);
             })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -171,26 +174,17 @@ public class OneTableClient {
   }
 
   private <COMMIT> SyncResultForTableFormats syncIncrementalChanges(
-      Map<TableFormat, TableFormatSync> syncClientByFormat, ExtractFromSource<COMMIT> source) {
+      Map<TableFormat, TableFormatSync> syncClientByFormat,
+      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
+      ExtractFromSource<COMMIT> source) {
     Map<TableFormat, SyncResult> syncResultsByFormat = new HashMap<>();
     OneTable syncedTable = null;
-    // State for each TableFormat
-    Map<TableFormat, Optional<Instant>> lastSyncInstantByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey, entry -> entry.getValue().getLastSyncInstant()));
-    // TODO: Simplify consolidation of storing lastInstant and inFlightInstants together.
-    Map<TableFormat, List<Instant>> pendingInstantsToConsiderForNextSyncByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> entry.getValue().getPendingInstantsToConsiderForNextSync()));
+
+    Map<TableFormat, Optional<OneTableMetadata>> filteredSyncMetadataByFormat =
+        lastSyncMetadataByFormat.entrySet().stream().filter(entry -> syncClientByFormat.containsKey(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     InstantsForIncrementalSync instantsForIncrementalSync =
-        getMostOutOfSyncCommitAndPendingCommits(
-            lastSyncInstantByFormat, pendingInstantsToConsiderForNextSyncByFormat);
+        getMostOutOfSyncCommitAndPendingCommits(filteredSyncMetadataByFormat);
     IncrementalTableChanges incrementalTableChanges =
         source.extractTableChanges(instantsForIncrementalSync);
     if (!incrementalTableChanges.getTableChanges().isEmpty()) {
@@ -198,8 +192,10 @@ public class OneTableClient {
         TableFormat tableFormat = entry.getKey();
         TableFormatSync tableFormatSync = entry.getValue();
         List<Instant> pendingSyncsByFormat =
-            pendingInstantsToConsiderForNextSyncByFormat.getOrDefault(
-                tableFormat, Collections.emptyList());
+            filteredSyncMetadataByFormat
+                .get(tableFormat)
+                .map(OneTableMetadata::getInstantsToConsiderForNextSync)
+                .orElse(Collections.emptyList());
         Set<Instant> pendingInstantsSet = new HashSet<>(pendingSyncsByFormat);
         // extract the changes that happened since this format was last synced
         List<TableChange> filteredTableChanges =
@@ -209,7 +205,11 @@ public class OneTableClient {
                         change
                                 .getTableAsOfChange()
                                 .getLatestCommitTime()
-                                .isAfter(lastSyncInstantByFormat.get(tableFormat).get())
+                                .isAfter(
+                                    filteredSyncMetadataByFormat
+                                        .get(tableFormat)
+                                        .map(OneTableMetadata::getLastInstantSynced)
+                                        .get())
                             || pendingInstantsSet.contains(
                                 change.getTableAsOfChange().getLatestCommitTime()))
                 .collect(Collectors.toList());
@@ -274,16 +274,21 @@ public class OneTableClient {
   }
 
   private InstantsForIncrementalSync getMostOutOfSyncCommitAndPendingCommits(
-      Map<TableFormat, Optional<Instant>> lastSyncInstantByFormat,
-      Map<TableFormat, List<Instant>> pendingInstantsToConsiderByFormat) {
+      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat) {
     Optional<Instant> mostOutOfSyncCommit =
-        lastSyncInstantByFormat.values().stream()
+        lastSyncMetadataByFormat.values().stream()
             .filter(Optional::isPresent)
             .map(Optional::get)
+            .map(OneTableMetadata::getLastInstantSynced)
             .sorted()
             .findFirst();
     List<Instant> allPendingInstants =
-        pendingInstantsToConsiderByFormat.values().stream()
+        lastSyncMetadataByFormat.values().stream()
+            .map(
+                oneTableMetadata ->
+                    oneTableMetadata
+                        .map(OneTableMetadata::getInstantsToConsiderForNextSync)
+                        .orElse(Collections.emptyList()))
             .flatMap(Collection::stream)
             .distinct()
             .sorted()

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -181,7 +181,9 @@ public class OneTableClient {
     OneTable syncedTable = null;
 
     Map<TableFormat, Optional<OneTableMetadata>> filteredSyncMetadataByFormat =
-        lastSyncMetadataByFormat.entrySet().stream().filter(entry -> syncClientByFormat.containsKey(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        lastSyncMetadataByFormat.entrySet().stream()
+            .filter(entry -> syncClientByFormat.containsKey(entry.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     InstantsForIncrementalSync instantsForIncrementalSync =
         getMostOutOfSyncCommitAndPendingCommits(filteredSyncMetadataByFormat);

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.onetable.model.OneTableMetadata;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +46,7 @@ import io.onetable.model.IncrementalTableChanges;
 import io.onetable.model.InstantsForIncrementalSync;
 import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
+import io.onetable.model.OneTableMetadata;
 import io.onetable.model.TableChange;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
@@ -133,8 +133,12 @@ public class TestOneTableClient {
         Arrays.asList(instantAt15, instantAt14, instantAt10, instantAt8, instantAt5, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
-    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
+    when(mockTableFormatSync1.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
+    when(mockTableFormatSync2.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -186,7 +190,8 @@ public class TestOneTableClient {
     when(mockSourceClient.isIncrementalSyncSafeFrom(eq(instantAt5))).thenReturn(false);
 
     // Both Iceberg and Delta last synced at instantAt5 and have no pending instants.
-    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(instantAt5, Collections.emptyList())));
+    when(mockTableFormatSync1.getTableMetadata())
+        .thenReturn(Optional.of(OneTableMetadata.of(instantAt5, Collections.emptyList())));
 
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
     when(mockTableFormatSync1.syncSnapshot(eq(oneSnapshot))).thenReturn(syncResult);
@@ -236,8 +241,12 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
-    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
+    when(mockTableFormatSync1.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
+    when(mockTableFormatSync2.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -296,8 +305,12 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt5);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
-    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync1.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync2.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -347,8 +360,12 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Collections.emptyList();
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
-    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync1.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync2.getTableMetadata())
+        .thenReturn(
+            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     // Iceberg and Delta have no commits to sync
     Map<TableFormat, SyncResult> expectedSyncResult = Collections.emptyMap();

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.onetable.model.OneTableMetadata;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
@@ -132,12 +133,8 @@ public class TestOneTableClient {
         Arrays.asList(instantAt15, instantAt14, instantAt10, instantAt8, instantAt5, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForIceberg);
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForDelta);
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -189,9 +186,7 @@ public class TestOneTableClient {
     when(mockSourceClient.isIncrementalSyncSafeFrom(eq(instantAt5))).thenReturn(false);
 
     // Both Iceberg and Delta last synced at instantAt5 and have no pending instants.
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(instantAt5));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(instantAt5, Collections.emptyList())));
 
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
     when(mockTableFormatSync1.syncSnapshot(eq(oneSnapshot))).thenReturn(syncResult);
@@ -241,12 +236,8 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForIceberg);
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForDelta);
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -305,12 +296,8 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt5);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -360,12 +347,8 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Collections.emptyList();
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     // Iceberg and Delta have no commits to sync
     Map<TableFormat, SyncResult> expectedSyncResult = Collections.emptyMap();


### PR DESCRIPTION
## What is the purpose of the pull request

This is preparation for a larger change for #148 where we'll make the table changes return as an iterator to avoid loading all changes into memory at once.

## Brief change log

- Leverages existing metadata to reduce number of maps maintained
- Ensures the target state is read once for efficiency 

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
