### PR TITLE
Use iterator over table changes during incremental sync

### DIFF
--- a/api/src/main/java/io/onetable/model/IncrementalTableChanges.java
+++ b/api/src/main/java/io/onetable/model/IncrementalTableChanges.java
@@ -20,6 +20,7 @@ package io.onetable.model;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import lombok.Builder;
@@ -29,7 +30,7 @@ import lombok.Value;
 @Value
 @Builder
 public class IncrementalTableChanges {
-  List<TableChange> tableChanges;
+  Iterator<TableChange> tableChanges;
   // pending commits before latest commit(write) on the table.
   @Builder.Default List<Instant> pendingCommits = Collections.emptyList();
 }

--- a/api/src/main/java/io/onetable/model/sync/SyncResult.java
+++ b/api/src/main/java/io/onetable/model/sync/SyncResult.java
@@ -53,6 +53,8 @@ public class SyncResult {
   @Value
   @Builder
   public static class SyncStatus {
+    public static SyncStatus SUCCESS =
+        SyncStatus.builder().statusCode(SyncStatusCode.SUCCESS).build();
     // Status code
     SyncStatusCode statusCode;
     // error Message if any

--- a/api/src/main/java/io/onetable/spi/extractor/ExtractFromSource.java
+++ b/api/src/main/java/io/onetable/spi/extractor/ExtractFromSource.java
@@ -19,6 +19,7 @@
 package io.onetable.spi.extractor;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
@@ -41,13 +42,9 @@ public class ExtractFromSource<COMMIT> {
     CommitsBacklog<COMMIT> commitsBacklog =
         sourceClient.getCommitsBacklog(instantsForIncrementalSync);
     // No overlap between updatedPendingCommits and commitList, process separately.
-    List<TableChange> tableChangeList = new ArrayList<>();
-    for (COMMIT commit : commitsBacklog.getCommitsToProcess()) {
-      TableChange tableChange = sourceClient.getTableChangeForCommit(commit);
-      tableChangeList.add(tableChange);
-    }
+    Iterator<TableChange> tableChangeIterator = commitsBacklog.getCommitsToProcess().stream().map(sourceClient::getTableChangeForCommit).iterator();
     return IncrementalTableChanges.builder()
-        .tableChanges(tableChangeList)
+        .tableChanges(tableChangeIterator)
         .pendingCommits(commitsBacklog.getInFlightInstants())
         .build();
   }

--- a/api/src/main/java/io/onetable/spi/extractor/ExtractFromSource.java
+++ b/api/src/main/java/io/onetable/spi/extractor/ExtractFromSource.java
@@ -18,9 +18,7 @@
  
 package io.onetable.spi.extractor;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -42,7 +40,10 @@ public class ExtractFromSource<COMMIT> {
     CommitsBacklog<COMMIT> commitsBacklog =
         sourceClient.getCommitsBacklog(instantsForIncrementalSync);
     // No overlap between updatedPendingCommits and commitList, process separately.
-    Iterator<TableChange> tableChangeIterator = commitsBacklog.getCommitsToProcess().stream().map(sourceClient::getTableChangeForCommit).iterator();
+    Iterator<TableChange> tableChangeIterator =
+        commitsBacklog.getCommitsToProcess().stream()
+            .map(sourceClient::getTableChangeForCommit)
+            .iterator();
     return IncrementalTableChanges.builder()
         .tableChanges(tableChangeIterator)
         .pendingCommits(commitsBacklog.getInFlightInstants())

--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -162,8 +162,7 @@ public class TableFormatSync {
 
     return SyncResult.builder()
         .mode(mode)
-        .status(
-            SyncResult.SyncStatus.builder().statusCode(SyncResult.SyncStatusCode.SUCCESS).build())
+        .status(SyncResult.SyncStatus.SUCCESS)
         .syncStartTime(startTime)
         .syncDuration(Duration.between(startTime, Instant.now()))
         .lastInstantSynced(tableState.getLatestCommitTime())

--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -96,7 +96,8 @@ public class TableFormatSync {
       IncrementalTableChanges changes) {
     Map<TableFormat, List<SyncResult>> results = new HashMap<>();
     Set<TargetClient> clientsWithFailures = new HashSet<>();
-    for (TableChange change : changes.getTableChanges()) {
+    while (changes.getTableChanges().hasNext()) {
+      TableChange change = changes.getTableChanges().next();
       Collection<TargetClient> clientsToSync =
           filteredSyncMetadataByClient.entrySet().stream()
               .filter(

--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -94,15 +94,8 @@ public class TableFormatSync {
     return results;
   }
 
-  public Optional<Instant> getLastSyncInstant() {
-    return client.getTableMetadata().map(OneTableMetadata::getLastInstantSynced);
-  }
-
-  public List<Instant> getPendingInstantsToConsiderForNextSync() {
-    return client
-        .getTableMetadata()
-        .map(OneTableMetadata::getInstantsToConsiderForNextSync)
-        .orElse(Collections.emptyList());
+  public Optional<OneTableMetadata> getTableMetadata() {
+    return client.getTableMetadata();
   }
 
   private SyncResult getSyncResult(

--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -30,6 +30,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 import io.onetable.model.IncrementalTableChanges;
@@ -43,7 +45,13 @@ import io.onetable.model.sync.SyncResult;
 
 /** Provides the functionality to sync from the OneTable format to the target format. */
 @Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TableFormatSync {
+  private static final TableFormatSync INSTANCE = new TableFormatSync();
+
+  public static TableFormatSync getInstance() {
+    return INSTANCE;
+  }
 
   /**
    * Syncs the provided snapshot to the target table format.

--- a/api/src/main/java/io/onetable/spi/sync/TargetClient.java
+++ b/api/src/main/java/io/onetable/spi/sync/TargetClient.java
@@ -27,6 +27,7 @@ import io.onetable.model.schema.OnePartitionField;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.storage.OneDataFilesDiff;
 import io.onetable.model.storage.OneFileGroup;
+import io.onetable.model.storage.TableFormat;
 
 /** A client that provides the major functionality for syncing changes to a target system. */
 public interface TargetClient {
@@ -81,4 +82,7 @@ public interface TargetClient {
 
   /** Returns the onetable metadata persisted in the target */
   Optional<OneTableMetadata> getTableMetadata();
+
+  /** Returns the {@link io.onetable.model.storage.TableFormat} the client syncs to */
+  TableFormat getTableFormat();
 }

--- a/api/src/test/java/io/onetable/spi/extractor/TestExtractFromSource.java
+++ b/api/src/test/java/io/onetable/spi/extractor/TestExtractFromSource.java
@@ -28,8 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.stream.StreamSupport;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -129,11 +127,13 @@ public class TestExtractFromSource {
                     .build())
             .build();
 
-    IncrementalTableChanges actual = ExtractFromSource.of(mockSourceClient).extractTableChanges(instantsForIncrementalSync);
+    IncrementalTableChanges actual =
+        ExtractFromSource.of(mockSourceClient).extractTableChanges(instantsForIncrementalSync);
     assertEquals(Collections.singletonList(inflightInstant), actual.getPendingCommits());
     List<TableChange> actualTableChanges = new ArrayList<>();
     actual.getTableChanges().forEachRemaining(actualTableChanges::add);
-    assertEquals(Arrays.asList(expectedFirstTableChange, expectedSecondTableChange), actualTableChanges);
+    assertEquals(
+        Arrays.asList(expectedFirstTableChange, expectedSecondTableChange), actualTableChanges);
   }
 
   private OneDataFile getOneDataFile(String partitionPath, String physicalPath) {

--- a/api/src/test/java/io/onetable/spi/extractor/TestExtractFromSource.java
+++ b/api/src/test/java/io/onetable/spi/extractor/TestExtractFromSource.java
@@ -24,9 +24,12 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -70,11 +73,13 @@ public class TestExtractFromSource {
     Instant lastSyncTime = Instant.now().minus(2, ChronoUnit.DAYS);
     TestCommit firstCommitToSync = TestCommit.of("first_commit");
     TestCommit secondCommitToSync = TestCommit.of("second_commit");
+    Instant inflightInstant = Instant.now().minus(1, ChronoUnit.HOURS);
     InstantsForIncrementalSync instantsForIncrementalSync =
         InstantsForIncrementalSync.builder().lastSyncInstant(lastSyncTime).build();
     CommitsBacklog<TestCommit> commitsBacklogToReturn =
         CommitsBacklog.<TestCommit>builder()
             .commitsToProcess(Arrays.asList(firstCommitToSync, secondCommitToSync))
+            .inFlightInstants(Collections.singletonList(inflightInstant))
             .build();
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync))
         .thenReturn(commitsBacklogToReturn);
@@ -124,13 +129,11 @@ public class TestExtractFromSource {
                     .build())
             .build();
 
-    IncrementalTableChanges expected =
-        IncrementalTableChanges.builder()
-            .tableChanges(Arrays.asList(expectedFirstTableChange, expectedSecondTableChange))
-            .build();
-    assertEquals(
-        expected,
-        ExtractFromSource.of(mockSourceClient).extractTableChanges(instantsForIncrementalSync));
+    IncrementalTableChanges actual = ExtractFromSource.of(mockSourceClient).extractTableChanges(instantsForIncrementalSync);
+    assertEquals(Collections.singletonList(inflightInstant), actual.getPendingCommits());
+    List<TableChange> actualTableChanges = new ArrayList<>();
+    actual.getTableChanges().forEachRemaining(actualTableChanges::add);
+    assertEquals(Arrays.asList(expectedFirstTableChange, expectedSecondTableChange), actualTableChanges);
   }
 
   private OneDataFile getOneDataFile(String partitionPath, String physicalPath) {

--- a/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
+++ b/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package io.onetable.spi.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.onetable.model.IncrementalTableChanges;
+import io.onetable.model.OneSnapshot;
+import io.onetable.model.OneTable;
+import io.onetable.model.OneTableMetadata;
+import io.onetable.model.TableChange;
+import io.onetable.model.schema.OneField;
+import io.onetable.model.schema.OnePartitionField;
+import io.onetable.model.schema.OneSchema;
+import io.onetable.model.schema.PartitionTransformType;
+import io.onetable.model.storage.OneDataFile;
+import io.onetable.model.storage.OneDataFilesDiff;
+import io.onetable.model.storage.OneFileGroup;
+import io.onetable.model.storage.TableFormat;
+import io.onetable.model.sync.SyncMode;
+import io.onetable.model.sync.SyncResult;
+
+public class TestTableFormatSync {
+  private final TargetClient mockTargetClient1 = mock(TargetClient.class);
+  private final TargetClient mockTargetClient2 = mock(TargetClient.class);
+
+  @Test
+  void syncSnapshotWithFailureForOneFormat() {
+    Instant start = Instant.now();
+    OneTable startingTableState = getTableState(1);
+    List<OneFileGroup> fileGroups =
+        Collections.singletonList(
+            OneFileGroup.builder()
+                .files(
+                    Collections.singletonList(
+                        OneDataFile.builder().physicalPath("/tmp/path/file.parquet").build()))
+                .build());
+    List<Instant> pendingCommitInstants = Collections.singletonList(Instant.now());
+    OneSnapshot snapshot =
+        OneSnapshot.builder()
+            .table(startingTableState)
+            .partitionedDataFiles(fileGroups)
+            .pendingCommits(pendingCommitInstants)
+            .build();
+    when(mockTargetClient1.getTableFormat()).thenReturn(TableFormat.ICEBERG);
+    when(mockTargetClient2.getTableFormat()).thenReturn(TableFormat.DELTA);
+    doThrow(new RuntimeException("Failure")).when(mockTargetClient1).beginSync(startingTableState);
+    Map<TableFormat, SyncResult> result =
+        TableFormatSync.getInstance()
+            .syncSnapshot(Arrays.asList(mockTargetClient1, mockTargetClient2), snapshot);
+
+    assertEquals(2, result.size());
+    SyncResult successResult = result.get(TableFormat.DELTA);
+    assertEquals(SyncResult.SyncStatus.SUCCESS, successResult.getStatus());
+    assertEquals(SyncMode.FULL, successResult.getMode());
+    assertEquals(startingTableState.getLatestCommitTime(), successResult.getLastInstantSynced());
+    assertSyncResultTimes(successResult, start);
+
+    SyncResult failureResult = result.get(TableFormat.ICEBERG);
+    assertEquals(SyncMode.FULL, failureResult.getMode());
+    assertSyncResultTimes(failureResult, start);
+    assertEquals(
+        SyncResult.SyncStatus.builder()
+            .statusCode(SyncResult.SyncStatusCode.ERROR)
+            .errorMessage("Failure")
+            .errorDescription("Failed to sync FULL")
+            .canRetryOnFailure(true)
+            .build(),
+        failureResult.getStatus());
+
+    verifyBaseClientCalls(mockTargetClient2, startingTableState, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForSnapshot(fileGroups);
+    verify(mockTargetClient2).completeSync();
+    verify(mockTargetClient1, never()).completeSync();
+  }
+
+  private static void assertSyncResultTimes(SyncResult syncResult, Instant start) {
+    assertNotNull(syncResult.getSyncDuration());
+    assertTrue(syncResult.getSyncStartTime().isAfter(start));
+    assertTrue(syncResult.getSyncStartTime().isBefore(Instant.now()));
+  }
+
+  @Test
+  void syncChangesWithFailureForOneFormat() {
+    Instant start = Instant.now();
+    OneTable tableState1 = getTableState(1);
+    OneDataFilesDiff dataFilesDiff1 = getFilesDiff(1);
+    TableChange tableChange1 =
+        TableChange.builder().tableAsOfChange(tableState1).filesDiff(dataFilesDiff1).build();
+    OneTable tableState2 = getTableState(2);
+    OneDataFilesDiff dataFilesDiff2 = getFilesDiff(2);
+    TableChange tableChange2 =
+        TableChange.builder().tableAsOfChange(tableState2).filesDiff(dataFilesDiff2).build();
+    OneTable tableState3 = getTableState(3);
+    OneDataFilesDiff dataFilesDiff3 = getFilesDiff(3);
+    TableChange tableChange3 =
+        TableChange.builder().tableAsOfChange(tableState3).filesDiff(dataFilesDiff3).build();
+
+    List<Instant> pendingCommitInstants = Collections.singletonList(Instant.now());
+    when(mockTargetClient1.getTableFormat()).thenReturn(TableFormat.ICEBERG);
+    when(mockTargetClient2.getTableFormat()).thenReturn(TableFormat.DELTA);
+    // throw exception on second change and show that first change is still returned for this format
+    // and other client is not affected
+    doThrow(new RuntimeException("Failure")).when(mockTargetClient1).beginSync(tableState2);
+
+    List<TableChange> tableChanges = Arrays.asList(tableChange1, tableChange2, tableChange3);
+    IncrementalTableChanges incrementalTableChanges =
+        IncrementalTableChanges.builder()
+            .pendingCommits(pendingCommitInstants)
+            .tableChanges(tableChanges)
+            .build();
+
+    Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
+    clientWithMetadata.put(
+        mockTargetClient1,
+        Optional.of(
+            OneTableMetadata.of(
+                Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList())));
+    clientWithMetadata.put(
+        mockTargetClient2,
+        Optional.of(
+            OneTableMetadata.of(
+                Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList())));
+
+    Map<TableFormat, List<SyncResult>> result =
+        TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
+
+    assertEquals(2, result.size());
+    // Assert that there is one success followed by a failure
+    List<SyncResult> partialSuccessResults = result.get(TableFormat.ICEBERG);
+    assertEquals(2, partialSuccessResults.size());
+    assertEquals(SyncMode.INCREMENTAL, partialSuccessResults.get(0).getMode());
+    assertEquals(
+        tableChanges.get(0).getTableAsOfChange().getLatestCommitTime(),
+        partialSuccessResults.get(0).getLastInstantSynced());
+    assertEquals(SyncResult.SyncStatus.SUCCESS, partialSuccessResults.get(0).getStatus());
+    assertSyncResultTimes(partialSuccessResults.get(0), start);
+
+    assertEquals(SyncMode.INCREMENTAL, partialSuccessResults.get(1).getMode());
+    assertSyncResultTimes(partialSuccessResults.get(1), start);
+    assertEquals(
+        SyncResult.SyncStatus.builder()
+            .statusCode(SyncResult.SyncStatusCode.ERROR)
+            .errorMessage("Failure")
+            .errorDescription("Failed to sync INCREMENTAL")
+            .canRetryOnFailure(true)
+            .build(),
+        partialSuccessResults.get(1).getStatus());
+
+    // Assert that all 3 changes are properly synced to the other format
+    List<SyncResult> successResults = result.get(TableFormat.DELTA);
+    assertEquals(3, successResults.size());
+    for (int i = 0; i < 3; i++) {
+      assertEquals(SyncMode.INCREMENTAL, successResults.get(i).getMode());
+      assertEquals(
+          tableChanges.get(i).getTableAsOfChange().getLatestCommitTime(),
+          successResults.get(i).getLastInstantSynced());
+      assertEquals(SyncResult.SyncStatus.SUCCESS, successResults.get(i).getStatus());
+      assertSyncResultTimes(successResults.get(i), start);
+    }
+
+    verifyBaseClientCalls(mockTargetClient1, tableState1, pendingCommitInstants);
+    verify(mockTargetClient1).syncFilesForDiff(dataFilesDiff1);
+    verifyBaseClientCalls(mockTargetClient2, tableState1, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForDiff(dataFilesDiff1);
+    verifyBaseClientCalls(mockTargetClient2, tableState2, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForDiff(dataFilesDiff2);
+    verifyBaseClientCalls(mockTargetClient2, tableState3, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForDiff(dataFilesDiff3);
+    verify(mockTargetClient1, times(1)).completeSync();
+    verify(mockTargetClient2, times(3)).completeSync();
+  }
+
+  @Test
+  void syncChangesWithDifferentFormatsAndMetadata() {
+    Instant start = Instant.now();
+    OneTable tableState1 = getTableState(1);
+    OneDataFilesDiff dataFilesDiff1 = getFilesDiff(1);
+    TableChange tableChange1 =
+        TableChange.builder().tableAsOfChange(tableState1).filesDiff(dataFilesDiff1).build();
+    OneTable tableState2 = getTableState(2);
+    OneDataFilesDiff dataFilesDiff2 = getFilesDiff(2);
+    TableChange tableChange2 =
+        TableChange.builder().tableAsOfChange(tableState2).filesDiff(dataFilesDiff2).build();
+    OneTable tableState3 = getTableState(3);
+    OneDataFilesDiff dataFilesDiff3 = getFilesDiff(3);
+    TableChange tableChange3 =
+        TableChange.builder().tableAsOfChange(tableState3).filesDiff(dataFilesDiff3).build();
+
+    List<Instant> pendingCommitInstants = Collections.singletonList(Instant.now());
+    when(mockTargetClient1.getTableFormat()).thenReturn(TableFormat.ICEBERG);
+    when(mockTargetClient2.getTableFormat()).thenReturn(TableFormat.DELTA);
+
+    List<TableChange> tableChanges = Arrays.asList(tableChange1, tableChange2, tableChange3);
+    IncrementalTableChanges incrementalTableChanges =
+        IncrementalTableChanges.builder()
+            .pendingCommits(pendingCommitInstants)
+            .tableChanges(tableChanges)
+            .build();
+
+    Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
+    // mockTargetClient1 will have the first table change as a previously pending instant and
+    // otherwise be synced up to the 2nd change
+    clientWithMetadata.put(
+        mockTargetClient1,
+        Optional.of(
+            OneTableMetadata.of(
+                tableChange2.getTableAsOfChange().getLatestCommitTime(),
+                Collections.singletonList(
+                    tableChange1.getTableAsOfChange().getLatestCommitTime()))));
+    // mockTargetClient2 will have synced the first table change previously
+    clientWithMetadata.put(
+        mockTargetClient2,
+        Optional.of(
+            OneTableMetadata.of(
+                tableChange1.getTableAsOfChange().getLatestCommitTime(), Collections.emptyList())));
+
+    Map<TableFormat, List<SyncResult>> result =
+        TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
+
+    assertEquals(2, result.size());
+    // Assert that there is one success followed by a failure
+    List<SyncResult> client1Results = result.get(TableFormat.ICEBERG);
+    assertEquals(2, client1Results.size());
+    for (SyncResult client1Result : client1Results) {
+      assertEquals(SyncMode.INCREMENTAL, client1Result.getMode());
+      assertEquals(SyncResult.SyncStatus.SUCCESS, client1Result.getStatus());
+      assertSyncResultTimes(client1Result, start);
+    }
+    assertEquals(
+        tableChanges.get(0).getTableAsOfChange().getLatestCommitTime(),
+        client1Results.get(0).getLastInstantSynced());
+    assertEquals(
+        tableChanges.get(2).getTableAsOfChange().getLatestCommitTime(),
+        client1Results.get(1).getLastInstantSynced());
+
+    // Assert that all 2 changes are properly synced to the other format
+    List<SyncResult> client2Results = result.get(TableFormat.DELTA);
+    assertEquals(2, client2Results.size());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(SyncMode.INCREMENTAL, client2Results.get(i).getMode());
+      assertEquals(
+          tableChanges.get(i + 1).getTableAsOfChange().getLatestCommitTime(),
+          client2Results.get(i).getLastInstantSynced());
+      assertEquals(SyncResult.SyncStatus.SUCCESS, client2Results.get(i).getStatus());
+      assertSyncResultTimes(client2Results.get(i), start);
+    }
+
+    // client1 syncs table changes 1 and 3
+    verifyBaseClientCalls(mockTargetClient1, tableState1, pendingCommitInstants);
+    verify(mockTargetClient1).syncFilesForDiff(dataFilesDiff1);
+    verifyBaseClientCalls(mockTargetClient1, tableState3, pendingCommitInstants);
+    verify(mockTargetClient1).syncFilesForDiff(dataFilesDiff3);
+    verify(mockTargetClient1, times(2)).completeSync();
+    // client2 syncs table changes 2 and 3
+    verifyBaseClientCalls(mockTargetClient2, tableState2, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForDiff(dataFilesDiff2);
+    verifyBaseClientCalls(mockTargetClient2, tableState3, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForDiff(dataFilesDiff3);
+    verify(mockTargetClient2, times(2)).completeSync();
+  }
+
+  @Test
+  void syncChangesOneFormatWithNoRequiredChanges() {
+    Instant start = Instant.now();
+    OneTable tableState1 = getTableState(1);
+    OneDataFilesDiff dataFilesDiff1 = getFilesDiff(1);
+    TableChange tableChange1 =
+        TableChange.builder().tableAsOfChange(tableState1).filesDiff(dataFilesDiff1).build();
+
+    List<Instant> pendingCommitInstants = Collections.emptyList();
+    when(mockTargetClient1.getTableFormat()).thenReturn(TableFormat.ICEBERG);
+    when(mockTargetClient2.getTableFormat()).thenReturn(TableFormat.DELTA);
+
+    List<TableChange> tableChanges = Collections.singletonList(tableChange1);
+    IncrementalTableChanges incrementalTableChanges =
+        IncrementalTableChanges.builder()
+            .pendingCommits(pendingCommitInstants)
+            .tableChanges(tableChanges)
+            .build();
+
+    Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
+    // mockTargetClient1 will have nothing to sync
+    clientWithMetadata.put(
+        mockTargetClient1,
+        Optional.of(OneTableMetadata.of(Instant.now(), Collections.emptyList())));
+    // mockTargetClient2 will have synced the first table change previously
+    clientWithMetadata.put(
+        mockTargetClient2,
+        Optional.of(
+            OneTableMetadata.of(
+                Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList())));
+
+    Map<TableFormat, List<SyncResult>> result =
+        TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
+    assertEquals(1, result.size());
+    List<SyncResult> client2Results = result.get(TableFormat.DELTA);
+    assertEquals(1, client2Results.size());
+    client2Results.forEach(
+        syncResult -> {
+          assertEquals(SyncMode.INCREMENTAL, syncResult.getMode());
+          assertEquals(SyncResult.SyncStatus.SUCCESS, syncResult.getStatus());
+          assertSyncResultTimes(syncResult, start);
+        });
+
+    verify(mockTargetClient1, never()).beginSync(any());
+    verify(mockTargetClient1, never()).syncFilesForDiff(any());
+    verify(mockTargetClient1, never()).completeSync();
+
+    verifyBaseClientCalls(mockTargetClient2, tableState1, pendingCommitInstants);
+    verify(mockTargetClient2).syncFilesForDiff(dataFilesDiff1);
+  }
+
+  /**
+   * Creates a table state with the given id so the state is different between calls.
+   *
+   * @param id id to use in the names of certain fields
+   * @return the table
+   */
+  private static OneTable getTableState(int id) {
+    return OneTable.builder()
+        .tableFormat(TableFormat.HUDI)
+        .readSchema(OneSchema.builder().name(String.format("test_schema_%d", id)).build())
+        .partitioningFields(
+            Collections.singletonList(
+                OnePartitionField.builder()
+                    .sourceField(
+                        OneField.builder().name(String.format("partition_field_%d", id)).build())
+                    .transformType(PartitionTransformType.VALUE)
+                    .build()))
+        .latestCommitTime(Instant.now().minus(10 - id, ChronoUnit.MINUTES))
+        .basePath("/tmp/test")
+        .build();
+  }
+
+  private OneDataFilesDiff getFilesDiff(int id) {
+    return OneDataFilesDiff.builder()
+        .filesAdded(
+            Collections.singletonList(
+                OneDataFile.builder()
+                    .physicalPath(String.format("/tmp/path/file_%d.parquet", id))
+                    .build()))
+        .build();
+  }
+
+  private void verifyBaseClientCalls(
+      TargetClient mockClient, OneTable startingTableState, List<Instant> pendingCommitInstants) {
+    verify(mockClient).beginSync(startingTableState);
+    verify(mockClient).syncSchema(startingTableState.getReadSchema());
+    verify(mockClient).syncPartitionSpec(startingTableState.getPartitioningFields());
+    verify(mockClient)
+        .syncMetadata(
+            OneTableMetadata.of(startingTableState.getLatestCommitTime(), pendingCommitInstants));
+  }
+}

--- a/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
+++ b/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
@@ -143,7 +143,7 @@ public class TestTableFormatSync {
     IncrementalTableChanges incrementalTableChanges =
         IncrementalTableChanges.builder()
             .pendingCommits(pendingCommitInstants)
-            .tableChanges(tableChanges)
+            .tableChanges(tableChanges.iterator())
             .build();
 
     Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
@@ -231,7 +231,7 @@ public class TestTableFormatSync {
     IncrementalTableChanges incrementalTableChanges =
         IncrementalTableChanges.builder()
             .pendingCommits(pendingCommitInstants)
-            .tableChanges(tableChanges)
+            .tableChanges(tableChanges.iterator())
             .build();
 
     Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
@@ -312,7 +312,7 @@ public class TestTableFormatSync {
     IncrementalTableChanges incrementalTableChanges =
         IncrementalTableChanges.builder()
             .pendingCommits(pendingCommitInstants)
-            .tableChanges(tableChanges)
+            .tableChanges(tableChanges.iterator())
             .build();
 
     Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();

--- a/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
+++ b/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -146,17 +145,13 @@ public class TestTableFormatSync {
             .tableChanges(tableChanges.iterator())
             .build();
 
-    Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
+    Map<TargetClient, OneTableMetadata> clientWithMetadata = new HashMap<>();
     clientWithMetadata.put(
         mockTargetClient1,
-        Optional.of(
-            OneTableMetadata.of(
-                Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList())));
+        OneTableMetadata.of(Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList()));
     clientWithMetadata.put(
         mockTargetClient2,
-        Optional.of(
-            OneTableMetadata.of(
-                Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList())));
+        OneTableMetadata.of(Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList()));
 
     Map<TableFormat, List<SyncResult>> result =
         TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
@@ -234,22 +229,19 @@ public class TestTableFormatSync {
             .tableChanges(tableChanges.iterator())
             .build();
 
-    Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
+    Map<TargetClient, OneTableMetadata> clientWithMetadata = new HashMap<>();
     // mockTargetClient1 will have the first table change as a previously pending instant and
     // otherwise be synced up to the 2nd change
     clientWithMetadata.put(
         mockTargetClient1,
-        Optional.of(
-            OneTableMetadata.of(
-                tableChange2.getTableAsOfChange().getLatestCommitTime(),
-                Collections.singletonList(
-                    tableChange1.getTableAsOfChange().getLatestCommitTime()))));
+        OneTableMetadata.of(
+            tableChange2.getTableAsOfChange().getLatestCommitTime(),
+            Collections.singletonList(tableChange1.getTableAsOfChange().getLatestCommitTime())));
     // mockTargetClient2 will have synced the first table change previously
     clientWithMetadata.put(
         mockTargetClient2,
-        Optional.of(
-            OneTableMetadata.of(
-                tableChange1.getTableAsOfChange().getLatestCommitTime(), Collections.emptyList())));
+        OneTableMetadata.of(
+            tableChange1.getTableAsOfChange().getLatestCommitTime(), Collections.emptyList()));
 
     Map<TableFormat, List<SyncResult>> result =
         TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
@@ -315,17 +307,14 @@ public class TestTableFormatSync {
             .tableChanges(tableChanges.iterator())
             .build();
 
-    Map<TargetClient, Optional<OneTableMetadata>> clientWithMetadata = new HashMap<>();
+    Map<TargetClient, OneTableMetadata> clientWithMetadata = new HashMap<>();
     // mockTargetClient1 will have nothing to sync
     clientWithMetadata.put(
-        mockTargetClient1,
-        Optional.of(OneTableMetadata.of(Instant.now(), Collections.emptyList())));
+        mockTargetClient1, OneTableMetadata.of(Instant.now(), Collections.emptyList()));
     // mockTargetClient2 will have synced the first table change previously
     clientWithMetadata.put(
         mockTargetClient2,
-        Optional.of(
-            OneTableMetadata.of(
-                Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList())));
+        OneTableMetadata.of(Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList()));
 
     Map<TableFormat, List<SyncResult>> result =
         TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -29,13 +29,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 
 import org.apache.hadoop.conf.Configuration;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import io.onetable.model.IncrementalTableChanges;
 import io.onetable.model.InstantsForIncrementalSync;
@@ -61,20 +61,14 @@ import io.onetable.spi.sync.TargetClient;
  * </ul>
  */
 @Log4j2
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class OneTableClient {
   private final Configuration conf;
   private final TableFormatClientFactory tableFormatClientFactory;
-  private final TableFormatSync tableFormatSync = new TableFormatSync();
+  private final TableFormatSync tableFormatSync;
 
   public OneTableClient(Configuration conf) {
-    this.conf = conf;
-    this.tableFormatClientFactory = TableFormatClientFactory.getInstance();
-  }
-
-  @VisibleForTesting
-  OneTableClient(Configuration conf, TableFormatClientFactory tableFormatClientFactory) {
-    this.conf = conf;
-    this.tableFormatClientFactory = tableFormatClientFactory;
+    this(conf, TableFormatClientFactory.getInstance(), TableFormatSync.getInstance());
   }
 
   /**

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -183,17 +183,14 @@ public class OneTableClient {
         getMostOutOfSyncCommitAndPendingCommits(filteredSyncMetadataByFormat);
     IncrementalTableChanges incrementalTableChanges =
         source.extractTableChanges(instantsForIncrementalSync);
-    if (incrementalTableChanges.getTableChanges().hasNext()) {
-      Map<TableFormat, List<SyncResult>> allResults =
-          tableFormatSync.syncChanges(filteredSyncMetadataByFormat, incrementalTableChanges);
-      // return only the last sync result in the list of results for each format
-      syncResultsByFormat =
-          allResults.entrySet().stream()
-              .collect(
-                  Collectors.toMap(
-                      Map.Entry::getKey,
-                      entry -> entry.getValue().get(entry.getValue().size() - 1)));
-    }
+    Map<TableFormat, List<SyncResult>> allResults =
+        tableFormatSync.syncChanges(filteredSyncMetadataByFormat, incrementalTableChanges);
+    // return only the last sync result in the list of results for each format
+    syncResultsByFormat =
+        allResults.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey, entry -> entry.getValue().get(entry.getValue().size() - 1)));
     return SyncResultForTableFormats.builder().lastSyncResult(syncResultsByFormat).build();
   }
 

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -43,6 +43,7 @@ import io.onetable.model.IncrementalTableChanges;
 import io.onetable.model.InstantsForIncrementalSync;
 import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
+import io.onetable.model.OneTableMetadata;
 import io.onetable.model.TableChange;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
@@ -103,8 +104,14 @@ public class OneTableClient {
                     Function.identity(),
                     tableFormat ->
                         tableFormatClientFactory.createForFormat(tableFormat, config, conf)));
+    // State for each TableFormat
+    Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat =
+        syncClientByFormat.entrySet().stream()
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getTableMetadata()));
     Map<TableFormat, TableFormatSync> formatsToSyncIncrementally =
-        getFormatsToSyncIncrementally(config, syncClientByFormat, source.getSourceClient());
+        getFormatsToSyncIncrementally(
+            config, syncClientByFormat, lastSyncMetadataByFormat, source.getSourceClient());
     Map<TableFormat, TableFormatSync> formatsToSyncBySnapshot =
         syncClientByFormat.entrySet().stream()
             .filter(entry -> !formatsToSyncIncrementally.containsKey(entry.getKey()))
@@ -116,7 +123,7 @@ public class OneTableClient {
     SyncResultForTableFormats syncResultForIncrementalSync =
         formatsToSyncIncrementally.isEmpty()
             ? SyncResultForTableFormats.builder().build()
-            : syncIncrementalChanges(formatsToSyncIncrementally, source);
+            : syncIncrementalChanges(formatsToSyncIncrementally, lastSyncMetadataByFormat, source);
     log.info(
         "OneTable Sync is successful for the following formats " + config.getTargetTableFormats());
     Map<TableFormat, SyncResult> syncResultsMerged =
@@ -128,28 +135,24 @@ public class OneTableClient {
   private <COMMIT> Map<TableFormat, TableFormatSync> getFormatsToSyncIncrementally(
       PerTableConfig perTableConfig,
       Map<TableFormat, TableFormatSync> syncClientByFormat,
+      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
       SourceClient<COMMIT> sourceClient) {
     if (perTableConfig.getSyncMode() == SyncMode.FULL) {
       // Full sync requested by config, hence no incremental sync.
       return Collections.emptyMap();
     }
-    Map<TableFormat, Optional<Instant>> lastSyncInstantByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey, entry -> entry.getValue().getLastSyncInstant()));
-    Map<TableFormat, List<Instant>> pendingInstantsToConsiderForNextSyncByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> entry.getValue().getPendingInstantsToConsiderForNextSync()));
     return syncClientByFormat.entrySet().stream()
         .filter(
             entry -> {
-              Optional<Instant> lastSyncInstant = lastSyncInstantByFormat.get(entry.getKey());
+              Optional<Instant> lastSyncInstant =
+                  lastSyncMetadataByFormat
+                      .get(entry.getKey())
+                      .map(OneTableMetadata::getLastInstantSynced);
               List<Instant> pendingInstants =
-                  pendingInstantsToConsiderForNextSyncByFormat.get(entry.getKey());
+                  lastSyncMetadataByFormat
+                      .get(entry.getKey())
+                      .map(OneTableMetadata::getInstantsToConsiderForNextSync)
+                      .orElse(Collections.emptyList());
               return isIncrementalSyncSufficient(sourceClient, lastSyncInstant, pendingInstants);
             })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -171,26 +174,17 @@ public class OneTableClient {
   }
 
   private <COMMIT> SyncResultForTableFormats syncIncrementalChanges(
-      Map<TableFormat, TableFormatSync> syncClientByFormat, ExtractFromSource<COMMIT> source) {
+      Map<TableFormat, TableFormatSync> syncClientByFormat,
+      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
+      ExtractFromSource<COMMIT> source) {
     Map<TableFormat, SyncResult> syncResultsByFormat = new HashMap<>();
     OneTable syncedTable = null;
-    // State for each TableFormat
-    Map<TableFormat, Optional<Instant>> lastSyncInstantByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey, entry -> entry.getValue().getLastSyncInstant()));
-    // TODO: Simplify consolidation of storing lastInstant and inFlightInstants together.
-    Map<TableFormat, List<Instant>> pendingInstantsToConsiderForNextSyncByFormat =
-        syncClientByFormat.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> entry.getValue().getPendingInstantsToConsiderForNextSync()));
+
+    Map<TableFormat, Optional<OneTableMetadata>> filteredSyncMetadataByFormat =
+        lastSyncMetadataByFormat.entrySet().stream().filter(entry -> syncClientByFormat.containsKey(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     InstantsForIncrementalSync instantsForIncrementalSync =
-        getMostOutOfSyncCommitAndPendingCommits(
-            lastSyncInstantByFormat, pendingInstantsToConsiderForNextSyncByFormat);
+        getMostOutOfSyncCommitAndPendingCommits(filteredSyncMetadataByFormat);
     IncrementalTableChanges incrementalTableChanges =
         source.extractTableChanges(instantsForIncrementalSync);
     if (!incrementalTableChanges.getTableChanges().isEmpty()) {
@@ -198,8 +192,10 @@ public class OneTableClient {
         TableFormat tableFormat = entry.getKey();
         TableFormatSync tableFormatSync = entry.getValue();
         List<Instant> pendingSyncsByFormat =
-            pendingInstantsToConsiderForNextSyncByFormat.getOrDefault(
-                tableFormat, Collections.emptyList());
+            filteredSyncMetadataByFormat
+                .get(tableFormat)
+                .map(OneTableMetadata::getInstantsToConsiderForNextSync)
+                .orElse(Collections.emptyList());
         Set<Instant> pendingInstantsSet = new HashSet<>(pendingSyncsByFormat);
         // extract the changes that happened since this format was last synced
         List<TableChange> filteredTableChanges =
@@ -209,7 +205,11 @@ public class OneTableClient {
                         change
                                 .getTableAsOfChange()
                                 .getLatestCommitTime()
-                                .isAfter(lastSyncInstantByFormat.get(tableFormat).get())
+                                .isAfter(
+                                    filteredSyncMetadataByFormat
+                                        .get(tableFormat)
+                                        .map(OneTableMetadata::getLastInstantSynced)
+                                        .get())
                             || pendingInstantsSet.contains(
                                 change.getTableAsOfChange().getLatestCommitTime()))
                 .collect(Collectors.toList());
@@ -274,16 +274,21 @@ public class OneTableClient {
   }
 
   private InstantsForIncrementalSync getMostOutOfSyncCommitAndPendingCommits(
-      Map<TableFormat, Optional<Instant>> lastSyncInstantByFormat,
-      Map<TableFormat, List<Instant>> pendingInstantsToConsiderByFormat) {
+      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat) {
     Optional<Instant> mostOutOfSyncCommit =
-        lastSyncInstantByFormat.values().stream()
+        lastSyncMetadataByFormat.values().stream()
             .filter(Optional::isPresent)
             .map(Optional::get)
+            .map(OneTableMetadata::getLastInstantSynced)
             .sorted()
             .findFirst();
     List<Instant> allPendingInstants =
-        pendingInstantsToConsiderByFormat.values().stream()
+        lastSyncMetadataByFormat.values().stream()
+            .map(
+                oneTableMetadata ->
+                    oneTableMetadata
+                        .map(OneTableMetadata::getInstantsToConsiderForNextSync)
+                        .orElse(Collections.emptyList()))
             .flatMap(Collection::stream)
             .distinct()
             .sorted()

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -22,16 +22,13 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.onetable.spi.sync.TargetClient;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
@@ -45,13 +42,13 @@ import io.onetable.model.InstantsForIncrementalSync;
 import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
 import io.onetable.model.OneTableMetadata;
-import io.onetable.model.TableChange;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
 import io.onetable.model.sync.SyncResult;
 import io.onetable.spi.extractor.ExtractFromSource;
 import io.onetable.spi.extractor.SourceClient;
 import io.onetable.spi.sync.TableFormatSync;
+import io.onetable.spi.sync.TargetClient;
 
 /**
  * Responsible for completing the entire lifecycle of the sync process given {@link PerTableConfig}.
@@ -67,6 +64,7 @@ import io.onetable.spi.sync.TableFormatSync;
 public class OneTableClient {
   private final Configuration conf;
   private final TableFormatClientFactory tableFormatClientFactory;
+  private final TableFormatSync tableFormatSync = new TableFormatSync();
 
   public OneTableClient(Configuration conf) {
     this.conf = conf;
@@ -98,7 +96,7 @@ public class OneTableClient {
     SourceClient<COMMIT> sourceClient = sourceClientProvider.getSourceClientInstance(config);
     ExtractFromSource<COMMIT> source = ExtractFromSource.of(sourceClient);
 
-    Map<TableFormat, TableFormatSync> syncClientByFormat =
+    Map<TableFormat, TargetClient> syncClientByFormat =
         config.getTargetTableFormats().stream()
             .collect(
                 Collectors.toMap(
@@ -110,10 +108,10 @@ public class OneTableClient {
         syncClientByFormat.entrySet().stream()
             .collect(
                 Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getTableMetadata()));
-    Map<TableFormat, TableFormatSync> formatsToSyncIncrementally =
+    Map<TableFormat, TargetClient> formatsToSyncIncrementally =
         getFormatsToSyncIncrementally(
             config, syncClientByFormat, lastSyncMetadataByFormat, source.getSourceClient());
-    Map<TableFormat, TableFormatSync> formatsToSyncBySnapshot =
+    Map<TableFormat, TargetClient> formatsToSyncBySnapshot =
         syncClientByFormat.entrySet().stream()
             .filter(entry -> !formatsToSyncIncrementally.containsKey(entry.getKey()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -133,9 +131,9 @@ public class OneTableClient {
     return syncResultsMerged;
   }
 
-  private <COMMIT> Map<TableFormat, TableFormatSync> getFormatsToSyncIncrementally(
+  private <COMMIT> Map<TableFormat, TargetClient> getFormatsToSyncIncrementally(
       PerTableConfig perTableConfig,
-      Map<TableFormat, TableFormatSync> syncClientByFormat,
+      Map<TableFormat, TargetClient> syncClientByFormat,
       Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
       SourceClient<COMMIT> sourceClient) {
     if (perTableConfig.getSyncMode() == SyncMode.FULL) {
@@ -160,14 +158,10 @@ public class OneTableClient {
   }
 
   private <COMMIT> SyncResultForTableFormats syncSnapshot(
-      Map<TableFormat, TableFormatSync> syncClientByFormat, ExtractFromSource<COMMIT> source) {
-    Map<TableFormat, SyncResult> syncResultsByFormat = new HashMap<>();
+      Map<TableFormat, TargetClient> syncClientByFormat, ExtractFromSource<COMMIT> source) {
     OneSnapshot snapshot = source.extractSnapshot();
-    syncClientByFormat.forEach(
-        (tableFormat, tableFormatSync) -> {
-          SyncResult syncResult = tableFormatSync.syncSnapshot(snapshot);
-          syncResultsByFormat.put(tableFormat, syncResult);
-        });
+    Map<TableFormat, SyncResult> syncResultsByFormat =
+        tableFormatSync.syncSnapshot(syncClientByFormat.values(), snapshot);
     return SyncResultForTableFormats.builder()
         .lastSyncResult(syncResultsByFormat)
         .syncedTable(snapshot.getTable())
@@ -178,58 +172,35 @@ public class OneTableClient {
       Map<TableFormat, TargetClient> syncClientByFormat,
       Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
       ExtractFromSource<COMMIT> source) {
-    Map<TableFormat, SyncResult> syncResultsByFormat = new HashMap<>();
+    Map<TableFormat, SyncResult> syncResultsByFormat = Collections.emptyMap();
     OneTable syncedTable = null;
 
-    Map<TableFormat, Optional<OneTableMetadata>> filteredSyncMetadataByFormat =
-        lastSyncMetadataByFormat.entrySet().stream().filter(entry -> syncClientByFormat.containsKey(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    Map<TargetClient, Optional<OneTableMetadata>> filteredSyncMetadataByFormat =
+        lastSyncMetadataByFormat.entrySet().stream()
+            .filter(entry -> syncClientByFormat.containsKey(entry.getKey()))
+            .collect(
+                Collectors.toMap(
+                    entry -> syncClientByFormat.get(entry.getKey()), Map.Entry::getValue));
 
     InstantsForIncrementalSync instantsForIncrementalSync =
         getMostOutOfSyncCommitAndPendingCommits(filteredSyncMetadataByFormat);
     IncrementalTableChanges incrementalTableChanges =
         source.extractTableChanges(instantsForIncrementalSync);
     if (!incrementalTableChanges.getTableChanges().isEmpty()) {
-      for (Map.Entry<TableFormat, TableFormatSync> entry : syncClientByFormat.entrySet()) {
-        TableFormat tableFormat = entry.getKey();
-        TableFormatSync tableFormatSync = entry.getValue();
-        List<Instant> pendingSyncsByFormat =
-            filteredSyncMetadataByFormat
-                .get(tableFormat)
-                .map(OneTableMetadata::getInstantsToConsiderForNextSync)
-                .orElse(Collections.emptyList());
-        Set<Instant> pendingInstantsSet = new HashSet<>(pendingSyncsByFormat);
-        // extract the changes that happened since this format was last synced
-        List<TableChange> filteredTableChanges =
-            incrementalTableChanges.getTableChanges().stream()
-                .filter(
-                    change ->
-                        change
-                                .getTableAsOfChange()
-                                .getLatestCommitTime()
-                                .isAfter(
-                                    filteredSyncMetadataByFormat
-                                        .get(tableFormat)
-                                        .map(OneTableMetadata::getLastInstantSynced)
-                                        .get())
-                            || pendingInstantsSet.contains(
-                                change.getTableAsOfChange().getLatestCommitTime()))
-                .collect(Collectors.toList());
-        if (filteredTableChanges.isEmpty()) {
-          // no updates to sync
-          continue;
-        }
-        IncrementalTableChanges tableFormatIncrementalChanges =
-            IncrementalTableChanges.builder()
-                .tableChanges(filteredTableChanges)
-                .pendingCommits(incrementalTableChanges.getPendingCommits())
-                .build();
-        List<SyncResult> syncResultList =
-            tableFormatSync.syncChanges(tableFormatIncrementalChanges);
-        syncedTable =
-            filteredTableChanges.get(filteredTableChanges.size() - 1).getTableAsOfChange();
-        SyncResult latestSyncResult = syncResultList.get(syncResultList.size() - 1);
-        syncResultsByFormat.put(tableFormat, latestSyncResult);
-      }
+      syncedTable =
+          incrementalTableChanges
+              .getTableChanges()
+              .get(incrementalTableChanges.getTableChanges().size() - 1)
+              .getTableAsOfChange();
+      Map<TableFormat, List<SyncResult>> allResults =
+          tableFormatSync.syncChanges(filteredSyncMetadataByFormat, incrementalTableChanges);
+      // return only the last sync result in the list of results for each format
+      syncResultsByFormat =
+          allResults.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey,
+                      entry -> entry.getValue().get(entry.getValue().size() - 1)));
     }
     return SyncResultForTableFormats.builder()
         .lastSyncResult(syncResultsByFormat)
@@ -275,7 +246,7 @@ public class OneTableClient {
   }
 
   private InstantsForIncrementalSync getMostOutOfSyncCommitAndPendingCommits(
-      Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat) {
+      Map<TargetClient, Optional<OneTableMetadata>> lastSyncMetadataByFormat) {
     Optional<Instant> mostOutOfSyncCommit =
         lastSyncMetadataByFormat.values().stream()
             .filter(Optional::isPresent)

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.onetable.spi.sync.TargetClient;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
@@ -174,7 +175,7 @@ public class OneTableClient {
   }
 
   private <COMMIT> SyncResultForTableFormats syncIncrementalChanges(
-      Map<TableFormat, TableFormatSync> syncClientByFormat,
+      Map<TableFormat, TargetClient> syncClientByFormat,
       Map<TableFormat, Optional<OneTableMetadata>> lastSyncMetadataByFormat,
       ExtractFromSource<COMMIT> source) {
     Map<TableFormat, SyncResult> syncResultsByFormat = new HashMap<>();

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.conf.Configuration;
 import io.onetable.model.IncrementalTableChanges;
 import io.onetable.model.InstantsForIncrementalSync;
 import io.onetable.model.OneSnapshot;
-import io.onetable.model.OneTable;
 import io.onetable.model.OneTableMetadata;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
@@ -156,9 +155,7 @@ public class OneTableClient {
     OneSnapshot snapshot = source.extractSnapshot();
     Map<TableFormat, SyncResult> syncResultsByFormat =
         tableFormatSync.syncSnapshot(syncClientByFormat.values(), snapshot);
-    return SyncResultForTableFormats.builder()
-        .lastSyncResult(syncResultsByFormat)
-        .build();
+    return SyncResultForTableFormats.builder().lastSyncResult(syncResultsByFormat).build();
   }
 
   private <COMMIT> SyncResultForTableFormats syncIncrementalChanges(
@@ -188,9 +185,7 @@ public class OneTableClient {
                       Map.Entry::getKey,
                       entry -> entry.getValue().get(entry.getValue().size() - 1)));
     }
-    return SyncResultForTableFormats.builder()
-        .lastSyncResult(syncResultsByFormat)
-        .build();
+    return SyncResultForTableFormats.builder().lastSyncResult(syncResultsByFormat).build();
   }
 
   /**

--- a/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
+++ b/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
@@ -28,7 +28,7 @@ import io.onetable.exception.NotSupportedException;
 import io.onetable.hudi.HudiTargetClient;
 import io.onetable.iceberg.IcebergClient;
 import io.onetable.model.storage.TableFormat;
-import io.onetable.spi.sync.TableFormatSync;
+import io.onetable.spi.sync.TargetClient;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TableFormatClientFactory {
@@ -38,15 +38,15 @@ public class TableFormatClientFactory {
     return INSTANCE;
   }
 
-  public TableFormatSync createForFormat(
+  public TargetClient createForFormat(
       TableFormat tableFormat, PerTableConfig perTableConfig, Configuration configuration) {
     switch (tableFormat) {
       case ICEBERG:
-        return TableFormatSync.of(new IcebergClient(perTableConfig, configuration));
+        return new IcebergClient(perTableConfig, configuration);
       case DELTA:
-        return TableFormatSync.of(new DeltaClient(perTableConfig, configuration));
+        return new DeltaClient(perTableConfig, configuration);
       case HUDI:
-        return TableFormatSync.of(new HudiTargetClient(perTableConfig, configuration));
+        return new HudiTargetClient(perTableConfig, configuration);
       default:
         throw new NotSupportedException("Target format is not yet supported: " + tableFormat);
     }

--- a/core/src/main/java/io/onetable/delta/DeltaClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClient.java
@@ -58,6 +58,7 @@ import io.onetable.model.schema.OnePartitionField;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.storage.OneDataFilesDiff;
 import io.onetable.model.storage.OneFileGroup;
+import io.onetable.model.storage.TableFormat;
 import io.onetable.spi.sync.TargetClient;
 
 public class DeltaClient implements TargetClient {
@@ -167,6 +168,11 @@ public class DeltaClient implements TargetClient {
   public Optional<OneTableMetadata> getTableMetadata() {
     return OneTableMetadata.fromMap(
         JavaConverters.mapAsJavaMapConverter(deltaLog.metadata().configuration()).asJava());
+  }
+
+  @Override
+  public TableFormat getTableFormat() {
+    return TableFormat.DELTA;
   }
 
   @EqualsAndHashCode

--- a/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
@@ -91,6 +91,7 @@ import io.onetable.model.schema.OnePartitionField;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.storage.OneDataFilesDiff;
 import io.onetable.model.storage.OneFileGroup;
+import io.onetable.model.storage.TableFormat;
 import io.onetable.spi.sync.TargetClient;
 
 @Log4j2
@@ -285,6 +286,11 @@ public class HudiTargetClient implements TargetClient {
                       }
                     })
                 .flatMap(OneTableMetadata::fromMap));
+  }
+
+  @Override
+  public TableFormat getTableFormat() {
+    return TableFormat.HUDI;
   }
 
   private HoodieTableMetaClient getMetaClient() {

--- a/core/src/main/java/io/onetable/iceberg/IcebergClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergClient.java
@@ -43,6 +43,7 @@ import io.onetable.model.schema.OnePartitionField;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.storage.OneDataFilesDiff;
 import io.onetable.model.storage.OneFileGroup;
+import io.onetable.model.storage.TableFormat;
 import io.onetable.spi.sync.TargetClient;
 
 public class IcebergClient implements TargetClient {
@@ -207,5 +208,10 @@ public class IcebergClient implements TargetClient {
       return Optional.empty();
     }
     return OneTableMetadata.fromMap(table.properties());
+  }
+
+  @Override
+  public TableFormat getTableFormat() {
+    return TableFormat.ICEBERG;
   }
 }

--- a/core/src/test/java/io/onetable/ITOneTableClient.java
+++ b/core/src/test/java/io/onetable/ITOneTableClient.java
@@ -192,10 +192,8 @@ public class ITOneTableClient {
       oneTableClient.sync(perTableConfig, sourceClientProvider);
       checkDatasetEquivalence(sourceTableFormat, table, targetTableFormats, 100);
 
+      // make multiple commits and then sync
       table.insertRows(100);
-      oneTableClient.sync(perTableConfig, sourceClientProvider);
-      checkDatasetEquivalence(sourceTableFormat, table, targetTableFormats, 200);
-
       table.upsertRows(insertRecords.subList(0, 20));
       oneTableClient.sync(perTableConfig, sourceClientProvider);
       checkDatasetEquivalence(sourceTableFormat, table, targetTableFormats, 200);

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -21,6 +21,7 @@ package io.onetable.client;
 import static io.onetable.GenericTable.getTableName;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -29,7 +30,9 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -53,6 +56,8 @@ import io.onetable.model.sync.SyncMode;
 import io.onetable.model.sync.SyncResult;
 import io.onetable.spi.extractor.SourceClient;
 import io.onetable.spi.sync.TableFormatSync;
+import io.onetable.spi.sync.TargetClient;
+import org.mockito.ArgumentMatcher;
 
 @SuppressWarnings("rawtypes")
 public class TestOneTableClient {
@@ -62,8 +67,9 @@ public class TestOneTableClient {
   private final SourceClient mockSourceClient = mock(SourceClient.class);
   private final TableFormatClientFactory mockTableFormatClientFactory =
       mock(TableFormatClientFactory.class);
-  private final TableFormatSync mockTableFormatSync1 = mock(TableFormatSync.class);
-  private final TableFormatSync mockTableFormatSync2 = mock(TableFormatSync.class);
+  private final TableFormatSync tableFormatSync = mock(TableFormatSync.class);
+  private final TargetClient mockTargetClient1 = mock(TargetClient.class);
+  private final TargetClient mockTargetClient2 = mock(TargetClient.class);
 
   @Test
   void testAllSnapshotSyncAsPerConfig() {
@@ -72,24 +78,26 @@ public class TestOneTableClient {
     OneSnapshot oneSnapshot = buildOneSnapshot(oneTable, "v1");
     Instant instantBeforeHour = Instant.now().minus(Duration.ofHours(1));
     SyncResult syncResult = buildSyncResult(syncMode, instantBeforeHour);
+    Map<TableFormat, SyncResult> perTableResults = new HashMap<>();
+    perTableResults.put(TableFormat.ICEBERG, syncResult);
+    perTableResults.put(TableFormat.DELTA, syncResult);
     PerTableConfig perTableConfig =
         getPerTableConfig(Arrays.asList(TableFormat.ICEBERG, TableFormat.DELTA), syncMode);
     when(mockSourceClientProvider.getSourceClientInstance(perTableConfig))
         .thenReturn(mockSourceClient);
     when(mockTableFormatClientFactory.createForFormat(
             TableFormat.ICEBERG, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient1);
     when(mockTableFormatClientFactory.createForFormat(TableFormat.DELTA, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient2);
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
-    when(mockTableFormatSync1.syncSnapshot(eq(oneSnapshot))).thenReturn(syncResult);
-    OneTableClient oneTableClient = new OneTableClient(mockConf, mockTableFormatClientFactory);
-    Map<TableFormat, SyncResult> expectedResult = new HashMap<>();
-    expectedResult.put(TableFormat.ICEBERG, syncResult);
-    expectedResult.put(TableFormat.DELTA, syncResult);
+    when(tableFormatSync.syncSnapshot(argThat(containsAll(Arrays.asList(mockTargetClient1, mockTargetClient2))), eq(oneSnapshot)))
+        .thenReturn(perTableResults);
+    OneTableClient oneTableClient =
+        new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
     Map<TableFormat, SyncResult> result =
         oneTableClient.sync(perTableConfig, mockSourceClientProvider);
-    assertEquals(expectedResult, result);
+    assertEquals(perTableResults, result);
   }
 
   @Test
@@ -101,9 +109,9 @@ public class TestOneTableClient {
         .thenReturn(mockSourceClient);
     when(mockTableFormatClientFactory.createForFormat(
             TableFormat.ICEBERG, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient1);
     when(mockTableFormatClientFactory.createForFormat(TableFormat.DELTA, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync2);
+        .thenReturn(mockTargetClient2);
 
     Instant instantAsOfNow = Instant.now();
     Instant instantAt15 = getInstantAtLastNMinutes(instantAsOfNow, 15);
@@ -133,36 +141,42 @@ public class TestOneTableClient {
         Arrays.asList(instantAt15, instantAt14, instantAt10, instantAt8, instantAt5, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata())
+    Optional<OneTableMetadata> targetClient1Metadata = Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg));
+    when(mockTargetClient1.getTableMetadata())
         .thenReturn(
-            Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
-    when(mockTableFormatSync2.getTableMetadata())
+            targetClient1Metadata);
+    Optional<OneTableMetadata> targetClient2Metadata = Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta));
+    when(mockTargetClient2.getTableMetadata())
         .thenReturn(
-            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
+            targetClient2Metadata);
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
-    Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
+    List<TableChange> tableChanges = new ArrayList<>();
     for (Instant instant : instantsToProcess) {
       TableChange tableChange = getTableChange(instant);
-      instantTableChangeMap.put(instant, tableChange);
+      tableChanges.add(tableChange);
       when(mockSourceClient.getTableChangeForCommit(instant)).thenReturn(tableChange);
     }
     // Iceberg needs to sync last pending instant at instantAt15 and instants after last sync
     // instant
     // which is instantAt10 and so i.e. instantAt8, instantAt5, instantAt2.
-    List<SyncResult> icebergSyncResults =
-        mockForSyncChanges(
-            mockTableFormatSync1,
-            instantTableChangeMap,
-            Arrays.asList(instantAt15, instantAt8, instantAt5, instantAt2));
+    List<SyncResult> icebergSyncResults = buildSyncResults(Arrays.asList(instantAt15, instantAt8, instantAt5, instantAt2));
     // Delta needs to sync last pending instant at instantAt8 and instants after last sync instant
     // which is instantAt5 and so i.e. instantAt2.
-    List<SyncResult> deltaSyncResults =
-        mockForSyncChanges(
-            mockTableFormatSync2, instantTableChangeMap, Arrays.asList(instantAt8, instantAt2));
+    List<SyncResult> deltaSyncResults = buildSyncResults(Arrays.asList(instantAt8, instantAt2));
+    IncrementalTableChanges incrementalTableChanges =
+        IncrementalTableChanges.builder().tableChanges(tableChanges).build();
+    Map<TableFormat, List<SyncResult>> allResults = new HashMap<>();
+    allResults.put(TableFormat.ICEBERG, icebergSyncResults);
+    allResults.put(TableFormat.DELTA, deltaSyncResults);
+    Map<TargetClient, Optional<OneTableMetadata>> clientToMetadata = new HashMap<>();
+    clientToMetadata.put(mockTargetClient1, targetClient1Metadata);
+    clientToMetadata.put(mockTargetClient2, targetClient2Metadata);
+    when(tableFormatSync.syncChanges(clientToMetadata, incrementalTableChanges)).thenReturn(allResults);
     Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
     expectedSyncResult.put(TableFormat.ICEBERG, getLastSyncResult(icebergSyncResults));
     expectedSyncResult.put(TableFormat.DELTA, getLastSyncResult(deltaSyncResults));
-    OneTableClient oneTableClient = new OneTableClient(mockConf, mockTableFormatClientFactory);
+    OneTableClient oneTableClient =
+        new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
     Map<TableFormat, SyncResult> result =
         oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(expectedSyncResult, result);
@@ -175,33 +189,38 @@ public class TestOneTableClient {
     Instant instantBeforeHour = Instant.now().minus(Duration.ofHours(1));
     OneSnapshot oneSnapshot = buildOneSnapshot(oneTable, "v1");
     SyncResult syncResult = buildSyncResult(syncMode, instantBeforeHour);
+    Map<TableFormat, SyncResult> syncResults = new HashMap<>();
+    syncResults.put(TableFormat.ICEBERG, syncResult);
+    syncResults.put(TableFormat.DELTA, syncResult);
     PerTableConfig perTableConfig =
         getPerTableConfig(Arrays.asList(TableFormat.ICEBERG, TableFormat.DELTA), syncMode);
     when(mockSourceClientProvider.getSourceClientInstance(perTableConfig))
         .thenReturn(mockSourceClient);
     when(mockTableFormatClientFactory.createForFormat(
             TableFormat.ICEBERG, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient1);
     when(mockTableFormatClientFactory.createForFormat(TableFormat.DELTA, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient2);
 
     Instant instantAsOfNow = Instant.now();
     Instant instantAt5 = getInstantAtLastNMinutes(instantAsOfNow, 5);
     when(mockSourceClient.isIncrementalSyncSafeFrom(eq(instantAt5))).thenReturn(false);
 
     // Both Iceberg and Delta last synced at instantAt5 and have no pending instants.
-    when(mockTableFormatSync1.getTableMetadata())
+    when(mockTargetClient1.getTableMetadata())
+        .thenReturn(Optional.of(OneTableMetadata.of(instantAt5, Collections.emptyList())));
+    when(mockTargetClient2.getTableMetadata())
         .thenReturn(Optional.of(OneTableMetadata.of(instantAt5, Collections.emptyList())));
 
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
-    when(mockTableFormatSync1.syncSnapshot(eq(oneSnapshot))).thenReturn(syncResult);
-    OneTableClient oneTableClient = new OneTableClient(mockConf, mockTableFormatClientFactory);
-    Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
-    expectedSyncResult.put(TableFormat.ICEBERG, syncResult);
-    expectedSyncResult.put(TableFormat.DELTA, syncResult);
+    when(tableFormatSync.syncSnapshot(
+            argThat(containsAll(Arrays.asList(mockTargetClient1, mockTargetClient2))), eq(oneSnapshot)))
+        .thenReturn(syncResults);
+    OneTableClient oneTableClient =
+        new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
     Map<TableFormat, SyncResult> result =
         oneTableClient.sync(perTableConfig, mockSourceClientProvider);
-    assertEquals(expectedSyncResult, result);
+    assertEquals(syncResults, result);
   }
 
   @Test
@@ -213,9 +232,9 @@ public class TestOneTableClient {
         .thenReturn(mockSourceClient);
     when(mockTableFormatClientFactory.createForFormat(
             TableFormat.ICEBERG, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient1);
     when(mockTableFormatClientFactory.createForFormat(TableFormat.DELTA, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync2);
+        .thenReturn(mockTargetClient2);
 
     Instant instantAsOfNow = Instant.now();
     Instant instantAt15 = getInstantAtLastNMinutes(instantAsOfNow, 15);
@@ -241,17 +260,18 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata())
+    when(mockTargetClient1.getTableMetadata())
         .thenReturn(
             Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
-    when(mockTableFormatSync2.getTableMetadata())
+    Optional<OneTableMetadata> targetClient2Metadata = Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta));
+    when(mockTargetClient2.getTableMetadata())
         .thenReturn(
-            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
+            targetClient2Metadata);
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
-    Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
+    List<TableChange> tableChanges = new ArrayList<>();
     for (Instant instant : instantsToProcess) {
       TableChange tableChange = getTableChange(instant);
-      instantTableChangeMap.put(instant, tableChange);
+      tableChanges.add(tableChange);
       when(mockSourceClient.getTableChangeForCommit(instant)).thenReturn(tableChange);
     }
     // Iceberg needs to sync by snapshot since instant15 is affected by table clean-up.
@@ -259,77 +279,26 @@ public class TestOneTableClient {
     Instant instantBeforeHour = Instant.now().minus(Duration.ofHours(1));
     OneSnapshot oneSnapshot = buildOneSnapshot(oneTable, "v1");
     SyncResult syncResult = buildSyncResult(syncMode, instantBeforeHour);
+    Map<TableFormat, SyncResult> snapshotResult =
+        Collections.singletonMap(TableFormat.ICEBERG, syncResult);
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
-    when(mockTableFormatSync1.syncSnapshot(eq(oneSnapshot))).thenReturn(syncResult);
+    when(tableFormatSync.syncSnapshot(argThat(containsAll(Collections.singletonList(mockTargetClient1))), eq(oneSnapshot)))
+        .thenReturn(snapshotResult);
     // Delta needs to sync last pending instant at instantAt8 and instants after last sync instant
     // which is instantAt5 and so i.e. instantAt2.
-    List<SyncResult> deltaSyncResults =
-        mockForSyncChanges(
-            mockTableFormatSync2, instantTableChangeMap, Arrays.asList(instantAt8, instantAt2));
+    List<SyncResult> deltaSyncResults = buildSyncResults(Arrays.asList(instantAt8, instantAt2));
+    IncrementalTableChanges incrementalTableChanges =
+        IncrementalTableChanges.builder().tableChanges(tableChanges).build();
+    when(tableFormatSync.syncChanges(Collections.singletonMap(mockTargetClient2, targetClient2Metadata), incrementalTableChanges))
+        .thenReturn(Collections.singletonMap(TableFormat.DELTA, deltaSyncResults));
     Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
     expectedSyncResult.put(TableFormat.ICEBERG, syncResult);
     expectedSyncResult.put(TableFormat.DELTA, getLastSyncResult(deltaSyncResults));
-    OneTableClient oneTableClient = new OneTableClient(mockConf, mockTableFormatClientFactory);
+    OneTableClient oneTableClient =
+        new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
     Map<TableFormat, SyncResult> result =
         oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(expectedSyncResult, result);
-  }
-
-  @Test
-  void incrementalSyncWithNoPendingInstantsForOneFormat() {
-    SyncMode syncMode = SyncMode.INCREMENTAL;
-    PerTableConfig perTableConfig =
-        getPerTableConfig(Arrays.asList(TableFormat.ICEBERG, TableFormat.DELTA), syncMode);
-    when(mockSourceClientProvider.getSourceClientInstance(perTableConfig))
-        .thenReturn(mockSourceClient);
-    when(mockTableFormatClientFactory.createForFormat(
-            TableFormat.ICEBERG, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
-    when(mockTableFormatClientFactory.createForFormat(TableFormat.DELTA, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync2);
-
-    Instant instantAsOfNow = Instant.now();
-    Instant instantAt10 = getInstantAtLastNMinutes(instantAsOfNow, 10);
-    Instant instantAt8 = getInstantAtLastNMinutes(instantAsOfNow, 8);
-    Instant instantAt5 = getInstantAtLastNMinutes(instantAsOfNow, 5);
-
-    when(mockSourceClient.isIncrementalSyncSafeFrom(eq(instantAt10))).thenReturn(true);
-    when(mockSourceClient.isIncrementalSyncSafeFrom(eq(instantAt5))).thenReturn(true);
-
-    // Iceberg last synced at instantAt5, the last instant in the source
-    Instant icebergLastSyncInstant = instantAt5;
-    // Delta last synced at instantAt10
-    Instant deltaLastSyncInstant = instantAt10;
-    InstantsForIncrementalSync instantsForIncrementalSync =
-        InstantsForIncrementalSync.builder().lastSyncInstant(deltaLastSyncInstant).build();
-    List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt5);
-    CommitsBacklog<Instant> commitsBacklog =
-        CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata())
-        .thenReturn(
-            Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
-    when(mockTableFormatSync2.getTableMetadata())
-        .thenReturn(
-            Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
-    when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
-    Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
-    for (Instant instant : instantsToProcess) {
-      TableChange tableChange = getTableChange(instant);
-      instantTableChangeMap.put(instant, tableChange);
-      when(mockSourceClient.getTableChangeForCommit(instant)).thenReturn(tableChange);
-    }
-    // Iceberg has no commits to sync
-    // Delta needs to sync instants 8 and 5
-    List<SyncResult> deltaSyncResults =
-        mockForSyncChanges(
-            mockTableFormatSync2, instantTableChangeMap, Arrays.asList(instantAt8, instantAt5));
-    Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
-    expectedSyncResult.put(TableFormat.DELTA, getLastSyncResult(deltaSyncResults));
-    OneTableClient oneTableClient = new OneTableClient(mockConf, mockTableFormatClientFactory);
-    Map<TableFormat, SyncResult> result =
-        oneTableClient.sync(perTableConfig, mockSourceClientProvider);
-    assertEquals(expectedSyncResult, result);
-    verify(mockTableFormatSync1, never()).syncChanges(any());
   }
 
   @Test
@@ -341,9 +310,9 @@ public class TestOneTableClient {
         .thenReturn(mockSourceClient);
     when(mockTableFormatClientFactory.createForFormat(
             TableFormat.ICEBERG, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync1);
+        .thenReturn(mockTargetClient1);
     when(mockTableFormatClientFactory.createForFormat(TableFormat.DELTA, perTableConfig, mockConf))
-        .thenReturn(mockTableFormatSync2);
+        .thenReturn(mockTargetClient2);
 
     Instant instantAsOfNow = Instant.now();
     Instant instantAt5 = getInstantAtLastNMinutes(instantAsOfNow, 5);
@@ -360,41 +329,32 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Collections.emptyList();
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getTableMetadata())
+    when(mockTargetClient1.getTableMetadata())
         .thenReturn(
             Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
-    when(mockTableFormatSync2.getTableMetadata())
+    when(mockTargetClient2.getTableMetadata())
         .thenReturn(
             Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     // Iceberg and Delta have no commits to sync
     Map<TableFormat, SyncResult> expectedSyncResult = Collections.emptyMap();
-    OneTableClient oneTableClient = new OneTableClient(mockConf, mockTableFormatClientFactory);
+    OneTableClient oneTableClient =
+        new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
     Map<TableFormat, SyncResult> result =
         oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(expectedSyncResult, result);
-    verify(mockTableFormatSync1, never()).syncChanges(any());
-    verify(mockTableFormatSync2, never()).syncChanges(any());
+    verify(tableFormatSync, never()).syncChanges(any(), any());
   }
 
   private SyncResult getLastSyncResult(List<SyncResult> syncResults) {
     return syncResults.get(syncResults.size() - 1);
   }
 
-  private List<SyncResult> mockForSyncChanges(
-      TableFormatSync mockTableFormatSync,
-      Map<Instant, TableChange> instantTableChangeMap,
-      List<Instant> instantList) {
-    List<TableChange> requiredTableChanges =
-        instantList.stream().map(instantTableChangeMap::get).collect(Collectors.toList());
-    IncrementalTableChanges incrementalTableChanges =
-        IncrementalTableChanges.builder().tableChanges(requiredTableChanges).build();
-    List<SyncResult> syncResults =
+  private List<SyncResult> buildSyncResults(List<Instant> instantList) {
+    return
         instantList.stream()
             .map(instant -> buildSyncResult(SyncMode.INCREMENTAL, instant))
             .collect(Collectors.toList());
-    when(mockTableFormatSync.syncChanges(incrementalTableChanges)).thenReturn(syncResults);
-    return syncResults;
   }
 
   private TableChange getTableChange(Instant instant) {
@@ -429,5 +389,9 @@ public class TestOneTableClient {
         .targetTableFormats(targetTableFormats)
         .syncMode(syncMode)
         .build();
+  }
+
+  private static <T> ArgumentMatcher<Collection<T>> containsAll(Collection<T> expected) {
+    return actual -> actual.size() == expected.size() && actual.containsAll(expected);
   }
 }

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
@@ -64,7 +63,8 @@ import io.onetable.spi.sync.TargetClient;
 public class TestOneTableClient {
 
   private final Configuration mockConf = mock(Configuration.class);
-  private final SourceClientProvider<Instant> mockSourceClientProvider = mock(SourceClientProvider.class);
+  private final SourceClientProvider<Instant> mockSourceClientProvider =
+      mock(SourceClientProvider.class);
   private final SourceClient<Instant> mockSourceClient = mock(SourceClient.class);
   private final TableFormatClientFactory mockTableFormatClientFactory =
       mock(TableFormatClientFactory.class);
@@ -173,7 +173,8 @@ public class TestOneTableClient {
     Map<TargetClient, Optional<OneTableMetadata>> clientToMetadata = new HashMap<>();
     clientToMetadata.put(mockTargetClient1, targetClient1Metadata);
     clientToMetadata.put(mockTargetClient2, targetClient2Metadata);
-    when(tableFormatSync.syncChanges(eq(clientToMetadata), argThat(matches(incrementalTableChanges))))
+    when(tableFormatSync.syncChanges(
+            eq(clientToMetadata), argThat(matches(incrementalTableChanges))))
         .thenReturn(allResults);
     Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
     expectedSyncResult.put(TableFormat.ICEBERG, getLastSyncResult(icebergSyncResults));
@@ -400,9 +401,11 @@ public class TestOneTableClient {
     return actual -> actual.size() == expected.size() && actual.containsAll(expected);
   }
 
-  private static ArgumentMatcher<IncrementalTableChanges> matches(IncrementalTableChanges expected) {
-    return actual -> actual.getPendingCommits().equals(expected.getPendingCommits())
-        && iteratorsMatch(actual.getTableChanges(), expected.getTableChanges());
+  private static ArgumentMatcher<IncrementalTableChanges> matches(
+      IncrementalTableChanges expected) {
+    return actual ->
+        actual.getPendingCommits().equals(expected.getPendingCommits())
+            && iteratorsMatch(actual.getTableChanges(), expected.getTableChanges());
   }
 
   private static <T> boolean iteratorsMatch(Iterator<T> first, Iterator<T> second) {

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.onetable.model.OneTableMetadata;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
@@ -132,12 +133,8 @@ public class TestOneTableClient {
         Arrays.asList(instantAt15, instantAt14, instantAt10, instantAt8, instantAt5, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForIceberg);
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForDelta);
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -189,9 +186,7 @@ public class TestOneTableClient {
     when(mockSourceClient.isIncrementalSyncSafeFrom(eq(instantAt5))).thenReturn(false);
 
     // Both Iceberg and Delta last synced at instantAt5 and have no pending instants.
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(instantAt5));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(instantAt5, Collections.emptyList())));
 
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
     when(mockTableFormatSync1.syncSnapshot(eq(oneSnapshot))).thenReturn(syncResult);
@@ -241,12 +236,8 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt2);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForIceberg);
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(pendingInstantsForDelta);
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, pendingInstantsForIceberg)));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, pendingInstantsForDelta)));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -305,12 +296,8 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Arrays.asList(instantAt8, instantAt5);
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     Map<Instant, TableChange> instantTableChangeMap = new HashMap<>();
     for (Instant instant : instantsToProcess) {
@@ -360,12 +347,8 @@ public class TestOneTableClient {
     List<Instant> instantsToProcess = Collections.emptyList();
     CommitsBacklog<Instant> commitsBacklog =
         CommitsBacklog.<Instant>builder().commitsToProcess(instantsToProcess).build();
-    when(mockTableFormatSync1.getLastSyncInstant()).thenReturn(Optional.of(icebergLastSyncInstant));
-    when(mockTableFormatSync2.getLastSyncInstant()).thenReturn(Optional.of(deltaLastSyncInstant));
-    when(mockTableFormatSync1.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
-    when(mockTableFormatSync2.getPendingInstantsToConsiderForNextSync())
-        .thenReturn(Collections.emptyList());
+    when(mockTableFormatSync1.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(icebergLastSyncInstant, Collections.emptyList())));
+    when(mockTableFormatSync2.getTableMetadata()).thenReturn(Optional.of(OneTableMetadata.of(deltaLastSyncInstant, Collections.emptyList())));
     when(mockSourceClient.getCommitsBacklog(instantsForIncrementalSync)).thenReturn(commitsBacklog);
     // Iceberg and Delta have no commits to sync
     Map<TableFormat, SyncResult> expectedSyncResult = Collections.emptyMap();

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -170,9 +170,9 @@ public class TestOneTableClient {
     Map<TableFormat, List<SyncResult>> allResults = new HashMap<>();
     allResults.put(TableFormat.ICEBERG, icebergSyncResults);
     allResults.put(TableFormat.DELTA, deltaSyncResults);
-    Map<TargetClient, Optional<OneTableMetadata>> clientToMetadata = new HashMap<>();
-    clientToMetadata.put(mockTargetClient1, targetClient1Metadata);
-    clientToMetadata.put(mockTargetClient2, targetClient2Metadata);
+    Map<TargetClient, OneTableMetadata> clientToMetadata = new HashMap<>();
+    clientToMetadata.put(mockTargetClient1, targetClient1Metadata.get());
+    clientToMetadata.put(mockTargetClient2, targetClient2Metadata.get());
     when(tableFormatSync.syncChanges(
             eq(clientToMetadata), argThat(matches(incrementalTableChanges))))
         .thenReturn(allResults);
@@ -295,7 +295,7 @@ public class TestOneTableClient {
     IncrementalTableChanges incrementalTableChanges =
         IncrementalTableChanges.builder().tableChanges(tableChanges.iterator()).build();
     when(tableFormatSync.syncChanges(
-            eq(Collections.singletonMap(mockTargetClient2, targetClient2Metadata)),
+            eq(Collections.singletonMap(mockTargetClient2, targetClient2Metadata.get())),
             argThat(matches(incrementalTableChanges))))
         .thenReturn(Collections.singletonMap(TableFormat.DELTA, deltaSyncResults));
     Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSync.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSync.java
@@ -113,7 +113,7 @@ public class TestIcebergSync {
       Mockito.mock(IcebergPartitionSpecSync.class);
   private final IcebergColumnStatsConverter mockColumnStatsConverter =
       Mockito.mock(IcebergColumnStatsConverter.class);
-  private TableFormatSync icebergSync;
+  private IcebergClient icebergClient;
 
   private final OneSchema oneSchema =
       OneSchema.builder()
@@ -172,23 +172,22 @@ public class TestIcebergSync {
     tableName = "test-" + UUID.randomUUID();
     basePath = tempDir.resolve(tableName);
     Files.createDirectories(basePath);
-    icebergSync =
-        TableFormatSync.of(
-            new IcebergClient(
-                PerTableConfig.builder()
-                    .tableBasePath(basePath.toString())
-                    .tableName(tableName)
-                    .targetMetadataRetentionInHours(1)
-                    .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
-                    .build(),
-                new Configuration(),
-                mockSchemaExtractor,
-                mockSchemaSync,
-                mockPartitionSpecExtractor,
-                mockPartitionSpecSync,
-                IcebergDataFileUpdatesSync.of(
-                    mockColumnStatsConverter, IcebergPartitionValueConverter.getInstance()),
-                IcebergTableManager.of(new Configuration())));
+    icebergClient =
+        new IcebergClient(
+            PerTableConfig.builder()
+                .tableBasePath(basePath.toString())
+                .tableName(tableName)
+                .targetMetadataRetentionInHours(1)
+                .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
+                .build(),
+            new Configuration(),
+            mockSchemaExtractor,
+            mockSchemaSync,
+            mockPartitionSpecExtractor,
+            mockPartitionSpecSync,
+            IcebergDataFileUpdatesSync.of(
+                mockColumnStatsConverter, IcebergPartitionValueConverter.getInstance()),
+            IcebergTableManager.of(new Configuration()));
   }
 
   @Test
@@ -253,10 +252,10 @@ public class TestIcebergSync {
     mockColStatsForFile(dataFile2, 2);
     mockColStatsForFile(dataFile3, 1);
 
-    icebergSync.syncSnapshot(snapshot1);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot1);
     validateIcebergTable(tableName, table1, Sets.newHashSet(dataFile1, dataFile2), null);
 
-    icebergSync.syncSnapshot(snapshot2);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot2);
     validateIcebergTable(tableName, table2, Sets.newHashSet(dataFile2, dataFile3), null);
 
     ArgumentCaptor<Transaction> transactionArgumentCaptor =
@@ -356,7 +355,7 @@ public class TestIcebergSync {
     mockColStatsForFile(dataFile1, 1);
     mockColStatsForFile(dataFile2, 1);
     mockColStatsForFile(dataFile3, 1);
-    icebergSync.syncSnapshot(snapshot);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot);
 
     assertTrue(schemaArgumentCaptor.getValue().sameSchema(icebergSchema));
     validateIcebergTable(
@@ -412,7 +411,7 @@ public class TestIcebergSync {
     mockColStatsForFile(dataFile1, 1);
     mockColStatsForFile(dataFile2, 1);
     mockColStatsForFile(dataFile3, 1);
-    icebergSync.syncSnapshot(snapshot);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot);
 
     assertTrue(schemaArgumentCaptor.getValue().sameSchema(icebergSchema));
     validateIcebergTable(
@@ -465,7 +464,7 @@ public class TestIcebergSync {
     mockColStatsForFile(dataFile1, 1);
     mockColStatsForFile(dataFile2, 1);
     mockColStatsForFile(dataFile3, 1);
-    icebergSync.syncSnapshot(snapshot);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot);
 
     assertTrue(schemaArgumentCaptor.getValue().sameSchema(icebergSchema));
     validateIcebergTable(
@@ -533,7 +532,7 @@ public class TestIcebergSync {
     mockColStatsForFile(dataFile1, 1);
     mockColStatsForFile(dataFile2, 1);
     mockColStatsForFile(dataFile3, 1);
-    icebergSync.syncSnapshot(snapshot);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot);
 
     assertTrue(schemaArgumentCaptor.getValue().sameSchema(icebergSchema));
     validateIcebergTable(
@@ -591,7 +590,7 @@ public class TestIcebergSync {
     mockColStatsForFile(dataFile1, 1);
     mockColStatsForFile(dataFile2, 1);
     mockColStatsForFile(dataFile3, 1);
-    icebergSync.syncSnapshot(snapshot);
+    TableFormatSync.getInstance().syncSnapshot(Collections.singletonList(icebergClient), snapshot);
 
     assertTrue(schemaArgumentCaptor.getValue().sameSchema(icebergSchema));
     validateIcebergTable(


### PR DESCRIPTION
## What is the purpose of the pull request

As part of #148  this change uses an iterator over the table changes instead of loading all of the changes into memory at once to reduce the memory overhear.

## Brief change log

- Make TableChanges an iterator instead of a list
- Update TableFormatSync to be stateless and sync each target commit by commit instead of looping through all commits per target.

## Verify this pull request

- Added additional unit tests for TableFormatSync around the logic for filtering which commits are synced per target client
- Updated existing tests around new expectations