### PR TITLE
Add check for iceberg when incremental sync is not safe

### DIFF
--- a/core/src/main/java/io/onetable/iceberg/IcebergSourceClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSourceClient.java
@@ -218,9 +218,11 @@ public class IcebergSourceClient implements SourceClient<Snapshot> {
     return CommitsBacklog.<Snapshot>builder().commitsToProcess(snapshots).build();
   }
 
-  // Following checks are to be performed:
-  // 1. Check if snapshot at or before the provided instant exists.
-  // 2. Check if expiring of snapshots has impacted the provided instant.
+  /*
+   * Following checks are to be performed:
+   * 1. Check if snapshot at or before the provided instant exists.
+   * 2. Check if expiring of snapshots has impacted the provided instant.
+   */
   @Override
   public boolean isIncrementalSyncSafeFrom(Instant instant) {
     long timeInMillis = instant.toEpochMilli();
@@ -239,7 +241,7 @@ public class IcebergSourceClient implements SourceClient<Snapshot> {
       return false;
     }
     // Go from latest snapshot until targetSnapshotId through parent reference.
-    // nothing has to be null in this chain.
+    // nothing has to be null in this chain to guarantee safety of incremental sync.
     Long currentSnapshotId = iceTable.currentSnapshot().snapshotId();
     while (currentSnapshotId != null && currentSnapshotId != targetSnapshotId) {
       Snapshot currentSnapshot = iceTable.snapshot(currentSnapshotId);

--- a/core/src/test/java/io/onetable/TestIcebergTable.java
+++ b/core/src/test/java/io/onetable/TestIcebergTable.java
@@ -329,6 +329,10 @@ public class TestIcebergTable implements GenericTable<Record, String> {
     icebergTable.expireSnapshots().expireOlderThan(instant.toEpochMilli()).commit();
   }
 
+  public void expireSnapshot(Long snapshotId) {
+    icebergTable.expireSnapshots().expireSnapshotId(snapshotId).commit();
+  }
+
   private List<String> filterNullFields(List<String> partitionFields) {
     return partitionFields.stream().filter(Objects::nonNull).collect(Collectors.toList());
   }

--- a/core/src/test/java/io/onetable/TestIcebergTable.java
+++ b/core/src/test/java/io/onetable/TestIcebergTable.java
@@ -298,7 +298,11 @@ public class TestIcebergTable implements GenericTable<Record, String> {
   }
 
   public Long getLastCommitTimestamp() {
-    return icebergTable.currentSnapshot().timestampMillis();
+    return getLatestSnapshot().timestampMillis();
+  }
+
+  public Snapshot getLatestSnapshot() {
+    return icebergTable.currentSnapshot();
   }
 
   @SneakyThrows

--- a/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
@@ -303,8 +303,6 @@ public class ITIcebergSourceClient {
     }
   }
 
-  // TODO(vamshigv): This tests show for Iceberg, it is not safe for incremental syncs
-  // with expired snapshots.
   @SneakyThrows
   @Test
   public void testForIncrementalSyncSafetyCheck() {
@@ -316,7 +314,6 @@ public class ITIcebergSourceClient {
       // Insert 50 rows to INFO partition.
       List<Record> commit1Rows = testIcebergTable.insertRecordsForPartition(50, "INFO");
       Long timestamp1 = testIcebergTable.getLastCommitTimestamp();
-      Snapshot icebergSnapshotAfterCommit1 = testIcebergTable.getLatestSnapshot();
       PerTableConfig tableConfig =
           PerTableConfig.builder()
               .tableName(testIcebergTable.getTableName())
@@ -354,11 +351,10 @@ public class ITIcebergSourceClient {
         areFilesRemoved =
             areFilesRemoved | checkIfFileIsRemoved(activePathAfterCommit1, tableChange);
       }
-      assertTrue(areFilesRemoved);
-      assertTrue(icebergSourceClient.isIncrementalSyncSafeFrom(Instant.ofEpochMilli(timestamp1)));
+      assertFalse(icebergSourceClient.isIncrementalSyncSafeFrom(Instant.ofEpochMilli(timestamp1)));
       // Table doesn't have instant of this older commit, hence it is not safe.
       Instant instantAsOfHourAgo = Instant.now().minus(1, ChronoUnit.HOURS);
-      assertTrue(icebergSourceClient.isIncrementalSyncSafeFrom(instantAsOfHourAgo));
+      assertFalse(icebergSourceClient.isIncrementalSyncSafeFrom(instantAsOfHourAgo));
     }
   }
 

--- a/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
@@ -19,16 +19,22 @@
 package io.onetable.iceberg;
 
 import static io.onetable.GenericTable.getTableName;
+import static io.onetable.ValidationTestHelper.getAllFilePaths;
 import static io.onetable.ValidationTestHelper.validateOneSnapshot;
 import static io.onetable.ValidationTestHelper.validateTableChanges;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
@@ -297,11 +303,78 @@ public class ITIcebergSourceClient {
     }
   }
 
+  // TODO(vamshigv): This tests show for Iceberg, it is not safe for incremental syncs
+  // with expired snapshots.
+  @SneakyThrows
+  @Test
+  public void testForIncrementalSyncSafetyCheck() {
+    boolean isPartitioned = true;
+    String tableName = getTableName();
+    try (TestIcebergTable testIcebergTable =
+        TestIcebergTable.forStandardSchemaAndPartitioning(
+            tableName, isPartitioned ? "level" : null, tempDir, hadoopConf)) {
+      // Insert 50 rows to INFO partition.
+      List<Record> commit1Rows = testIcebergTable.insertRecordsForPartition(50, "INFO");
+      Long timestamp1 = testIcebergTable.getLastCommitTimestamp();
+      Snapshot icebergSnapshotAfterCommit1 = testIcebergTable.getLatestSnapshot();
+      PerTableConfig tableConfig =
+          PerTableConfig.builder()
+              .tableName(testIcebergTable.getTableName())
+              .tableBasePath(testIcebergTable.getBasePath())
+              .tableDataPath(testIcebergTable.getDataPath())
+              .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.DELTA))
+              .build();
+      IcebergSourceClient icebergSourceClient = clientProvider.getSourceClientInstance(tableConfig);
+      OneSnapshot snapshotAfterCommit1 = icebergSourceClient.getCurrentSnapshot();
+      List<String> allActivePaths = getAllFilePaths(snapshotAfterCommit1);
+      assertEquals(1, allActivePaths.size());
+      String activePathAfterCommit1 = allActivePaths.get(0);
+
+      // Upsert all rows inserted before, so all files are replaced.
+      testIcebergTable.upsertRows(commit1Rows.subList(0, 50));
+      Thread.sleep(5 * 1000);
+      Instant instantAfterCommit2 = Instant.now();
+
+      // Insert 50 rows to different (ERROR) partition.
+      testIcebergTable.insertRecordsForPartition(50, "ERROR");
+
+      // Expire two snapshots.
+      testIcebergTable.expireSnapshotsOlderThan(instantAfterCommit2);
+
+      InstantsForIncrementalSync instantsForIncrementalSync =
+          InstantsForIncrementalSync.builder()
+              .lastSyncInstant(Instant.ofEpochMilli(timestamp1))
+              .build();
+      icebergSourceClient = clientProvider.getSourceClientInstance(tableConfig);
+      CommitsBacklog<Snapshot> instantCurrentCommitState =
+          icebergSourceClient.getCommitsBacklog(instantsForIncrementalSync);
+      boolean areFilesRemoved = false;
+      for (Snapshot snapshot : instantCurrentCommitState.getCommitsToProcess()) {
+        TableChange tableChange = icebergSourceClient.getTableChangeForCommit(snapshot);
+        areFilesRemoved =
+            areFilesRemoved | checkIfFileIsRemoved(activePathAfterCommit1, tableChange);
+      }
+      assertTrue(areFilesRemoved);
+      assertTrue(icebergSourceClient.isIncrementalSyncSafeFrom(Instant.ofEpochMilli(timestamp1)));
+      // Table doesn't have instant of this older commit, hence it is not safe.
+      Instant instantAsOfHourAgo = Instant.now().minus(1, ChronoUnit.HOURS);
+      assertTrue(icebergSourceClient.isIncrementalSyncSafeFrom(instantAsOfHourAgo));
+    }
+  }
+
   private void validateIcebergPartitioning(OneSnapshot oneSnapshot) {
     List<OnePartitionField> partitionFields = oneSnapshot.getTable().getPartitioningFields();
     assertEquals(1, partitionFields.size());
     OnePartitionField partitionField = partitionFields.get(0);
     assertEquals("level", partitionField.getSourceField().getName());
     assertEquals(PartitionTransformType.VALUE, partitionField.getTransformType());
+  }
+
+  private boolean checkIfFileIsRemoved(String activePath, TableChange tableChange) {
+    Set<String> filePathsRemoved =
+        tableChange.getFilesDiff().getFilesRemoved().stream()
+            .map(oneDf -> oneDf.getPhysicalPath())
+            .collect(Collectors.toSet());
+    return filePathsRemoved.contains(activePath);
   }
 }

--- a/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
@@ -322,7 +322,6 @@ public class ITIcebergSourceClient {
       // Upsert all rows inserted before, so all files are replaced.
       testIcebergTable.upsertRows(commit1Rows.subList(0, 50));
       long snapshotIdAfterCommit2 = testIcebergTable.getLatestSnapshot().snapshotId();
-      Thread.sleep(5 * 1000);
 
       // Insert 50 rows to different (ERROR) partition.
       testIcebergTable.insertRecordsForPartition(50, "ERROR");


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Fallback to Full sync automatically when it is not safe for incremental sync.

## Brief change log

1. In the presence of expired snapshots, detect and fall back to snapshot sync.

## Verify this pull request

*(Please pick either of the following options)*

This change added tests and can be verified as follows: