### PR TITLE
Make project compilable against jdk8

### DIFF
--- a/core/src/main/java/io/onetable/hudi/BaseFileUpdatesExtractor.java
+++ b/core/src/main/java/io/onetable/hudi/BaseFileUpdatesExtractor.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package io.onetable.hudi;
 
 import static io.onetable.collectors.CustomCollectors.toList;
@@ -231,22 +231,26 @@ public class BaseFileUpdatesExtractor {
     return writeStatus;
   }
 
+  private HoodieColumnRangeMetadata<Comparable> convertColStat(
+      String fileName, ColumnStat columnStat) {
+    return HoodieColumnRangeMetadata.create(
+        fileName,
+        convertFromOneTablePath(columnStat.getField().getPath()),
+        (Comparable) columnStat.getRange().getMinValue(),
+        (Comparable) columnStat.getRange().getMaxValue(),
+        columnStat.getNumNulls(),
+        columnStat.getNumValues(),
+        columnStat.getTotalSize(),
+        -1L);
+  }
+
   private Map<String, HoodieColumnRangeMetadata<Comparable>> convertColStats(
       String fileName, List<ColumnStat> columnStatMap) {
     return columnStatMap.stream()
         .filter(
             entry -> !OneType.NON_SCALAR_TYPES.contains(entry.getField().getSchema().getDataType()))
         .map(
-            columnStat ->
-                HoodieColumnRangeMetadata.<Comparable>create(
-                    fileName,
-                    convertFromOneTablePath(columnStat.getField().getPath()),
-                    (Comparable) columnStat.getRange().getMinValue(),
-                    (Comparable) columnStat.getRange().getMaxValue(),
-                    columnStat.getNumNulls(),
-                    columnStat.getNumValues(),
-                    columnStat.getTotalSize(),
-                    -1L))
+            columnStat -> convertColStat(fileName, columnStat))
         .collect(Collectors.toMap(HoodieColumnRangeMetadata::getColumnName, Function.identity()));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <java.version>8</java.version>
+        <java.version>1.8</java.version>
         <avro.version>1.11.3</avro.version>
         <log4j.version>2.17.2</log4j.version>
         <junit.version>5.9.0</junit.version>
@@ -492,7 +492,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <release>${java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## What is the purpose of the pull request

Fixes #244 

## Brief change log
- Uses JDK8 compatible source and target configurations for Maven
- Uses syntax that is compatible to compile on JDK8 and beyond.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
- Verified by running `$ mvn clean package -DskipTests` locally.