### PR TITLE
Improve sync utility cli parse error messages

### DIFF
--- a/utilities/src/main/java/io/onetable/utilities/RunSync.java
+++ b/utilities/src/main/java/io/onetable/utilities/RunSync.java
@@ -72,7 +72,7 @@ public class RunSync {
 
   private static final Options OPTIONS =
       new Options()
-          .addOption(
+          .addRequiredOption(
               DATASET_CONFIG_OPTION,
               "datasetConfig",
               true,
@@ -93,12 +93,21 @@ public class RunSync {
               ICEBERG_CATALOG_CONFIG_PATH,
               "icebergCatalogConfig",
               true,
-              "The path to a yaml file containing Iceberg catalog configuration. The configuration will be used for any Iceberg source or target.")
+              "The path to a yaml file containing Iceberg catalog configuration. The configuration will be "
+                  + "used for any Iceberg source or target.")
           .addOption(HELP_OPTION, "help", false, "Displays help information to run this utility");
 
-  public static void main(String[] args) throws IOException, ParseException {
+  public static void main(String[] args) throws IOException {
     CommandLineParser parser = new DefaultParser();
-    CommandLine cmd = parser.parse(OPTIONS, args);
+
+    CommandLine cmd;
+    try {
+      cmd = parser.parse(OPTIONS, args);
+    } catch (ParseException e) {
+      new HelpFormatter().printHelp("onetable.jar", OPTIONS, true);
+      return;
+    }
+
     if (cmd.hasOption(HELP_OPTION)) {
       HelpFormatter formatter = new HelpFormatter();
       formatter.printHelp("RunSync", OPTIONS);


### PR DESCRIPTION
Fixes #254 

This is a minor enhancement in the `run sync` cli utility. Currently absence of required params does not produce useful error messages. With this change the help message will be printed. For e.g.

```
$ java -jar utilities/target/utilities-0.1.0-SNAPSHOT-bundled.jar                                
usage: onetable.jar [-c <arg>] -d <arg> [-h] [-i <arg>] [-p <arg>]
 -c,--clientsConfig <arg>          The path to a yaml file containing
                                   OneTable client configurations. These
                                   configs will override the default
 -d,--datasetConfig <arg>          The path to a yaml file containing
                                   dataset configuration
 -h,--help                         Displays help information to run this
                                   utility
 -i,--icebergCatalogConfig <arg>   The path to a yaml file containing
                                   Iceberg catalog configuration. The
                                   configuration will be used for any
                                   Iceberg source or target.
 -p,--hadoopConfig <arg>           Hadoop config xml file path containing
                                   configs necessary to access the file
                                   system. These configs will override the
                                   default configs.
```

This pull request is a trivial rework without any test coverage.