### PR TITLE
addresses 257

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,12 @@
+FROM bitnami/spark:3.2.4
+
+USER root
+
+# Install vim and cd to onetable
+RUN apt-get update \
+    && apt-get install -y vim \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /home/onetable \
+    && chmod -R 777 /home/onetable
+
+WORKDIR /home/onetable

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -1,5 +1,46 @@
 version: "3.9"
 services:
+  spark-master:
+    build:
+      context: .
+      dockerfile: Dockerfile # Dockerfile creates /home/onetable dir and gives permissions to user
+    environment:
+      - SPARK_MODE=master
+      - SPARK_MASTER_PORT=7077
+    ports:
+      - "18080:18080" # Spark master web UI port
+      - "7077:7077" # Spark master port
+    volumes:
+      - ./jars/utilities-0.1.0-SNAPSHOT-bundled.jar:/home/onetable/utilities/target/utilities-0.1.0-SNAPSHOT-bundled.jar
+
+  spark-worker-1:
+    image: bitnami/spark:3.2.4
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+    depends_on:
+      - spark-master
+
+  spark-worker-2:
+    image: bitnami/spark:3.2.4
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+    depends_on:
+      - spark-master
+
+  hive-metastore:
+    container_name: hive-metastore
+    hostname: hive-metastore
+    image: 'apache/hive:4.0.0-alpha-2'
+    ports:
+      - '9083:9083' # Metastore Thrift
+    environment:
+      SERVICE_NAME: metastore
+      HIVE_METASTORE_WAREHOUSE_DIR: /home/data
+    volumes:
+      - ./data:/home/data
+
   trino:
     container_name: trino
     ports:
@@ -19,18 +60,6 @@ services:
       - ./presto/config.properties:/opt/presto-server/etc/config.properties
       - ./presto/jvm.config:/opt/presto-server/etc/jvm.config
       - ./presto/node.properties:/opt/presto-server/etc/node.properties
-      - ./data:/home/data
-
-  hive-metastore:
-    container_name: hive-metastore
-    hostname: hive-metastore
-    image: 'apache/hive:4.0.0-alpha-2'
-    ports:
-      - '9083:9083' # Metastore Thrift
-    environment:
-      SERVICE_NAME: metastore
-      HIVE_METASTORE_WAREHOUSE_DIR: /home/data
-    volumes:
       - ./data:/home/data
 
   jupyter:

--- a/demo/start_demo.sh
+++ b/demo/start_demo.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Create the require jars for the demo and copy them into a directory we'll mount in our notebook container
-cd .. && mvn install -am -pl core -DskipTests -T 2
+# Create the require jars for the demo and copy them into a directory we'll mount in our notebook & spark container
+cd .. && mvn install -DskipTests -T 2
 mkdir -p demo/jars
 cp hudi-support/utils/target/hudi-utils-0.1.0-SNAPSHOT.jar demo/jars
 cp api/target/onetable-api-0.1.0-SNAPSHOT.jar demo/jars
 cp core/target/onetable-core-0.1.0-SNAPSHOT.jar demo/jars
+cp utilities/target/utilities-0.1.0-SNAPSHOT-bundled.jar demo/jars
 
 cd demo
 docker-compose up


### PR DESCRIPTION
## *Important Read*
https://github.com/onetable-io/onetable/issues/257

## What is the purpose of the pull request

Adds docker playground with spark and copies the bundled jar. This improvement lets the users to run the `how-to` tutorial,

## Brief change log

Adds docker playground and copies the onetable bundled jar.

## Verify this pull request

Ran local tests for docker.
[onetable-issue-257-tests.pdf](https://github.com/onetable-io/onetable/files/13465072/onetable-issue-257-tests.pdf)

Ran `npm start` and visually tested the docs.
<img width="1728" alt="Screenshot 2023-11-25 at 11 44 48 AM" src="https://github.com/onetable-io/onetable/assets/30472234/18640e2e-4257-4146-8c08-58c31ca88afc">
<img width="1728" alt="Screenshot 2023-11-25 at 11 44 50 AM" src="https://github.com/onetable-io/onetable/assets/30472234/bf3f74fc-480b-400d-a4b7-217fade72ef1">
