### PR TITLE
only set record key field in iceberg if it is a required field

### DIFF
--- a/core/src/main/java/io/onetable/iceberg/IcebergSchemaExtractor.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSchemaExtractor.java
@@ -67,7 +67,11 @@ public class IcebergSchemaExtractor {
     AtomicInteger fieldIdTracker = new AtomicInteger(0);
     List<Types.NestedField> nestedFields = convertFields(oneSchema, fieldIdTracker);
     List<OneField> recordKeyFields = oneSchema.getRecordKeyFields();
-    if (recordKeyFields.isEmpty()) {
+    boolean recordKeyFieldsAreNotRequired = recordKeyFields.stream().anyMatch(f -> f.getSchema().isNullable());
+    if (!recordKeyFields.isEmpty() && recordKeyFieldsAreNotRequired) {
+      log.warn("Record key fields are not required. Not setting record key fields in iceberg schema.");
+    }
+    if (recordKeyFields.isEmpty() || recordKeyFieldsAreNotRequired) {
       return new Schema(nestedFields);
     }
     // Find field in iceberg schema that matches each of the record key path and collect ids.

--- a/core/src/main/java/io/onetable/iceberg/IcebergSchemaExtractor.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSchemaExtractor.java
@@ -67,9 +67,13 @@ public class IcebergSchemaExtractor {
     AtomicInteger fieldIdTracker = new AtomicInteger(0);
     List<Types.NestedField> nestedFields = convertFields(oneSchema, fieldIdTracker);
     List<OneField> recordKeyFields = oneSchema.getRecordKeyFields();
-    boolean recordKeyFieldsAreNotRequired = recordKeyFields.stream().anyMatch(f -> f.getSchema().isNullable());
+    boolean recordKeyFieldsAreNotRequired =
+        recordKeyFields.stream().anyMatch(f -> f.getSchema().isNullable());
+    // Iceberg requires the identifier fields to be required fields, so if any of the record key
+    // fields are nullable, we cannot add the identifier fields to the schema properties.
     if (!recordKeyFields.isEmpty() && recordKeyFieldsAreNotRequired) {
-      log.warn("Record key fields are not required. Not setting record key fields in iceberg schema.");
+      log.warn(
+          "Record key fields are not required. Not setting record key fields in iceberg schema.");
     }
     if (recordKeyFields.isEmpty() || recordKeyFieldsAreNotRequired) {
       return new Schema(nestedFields);


### PR DESCRIPTION
## What is the purpose of the pull request

#261 
Usability improvement, if the record key field in hudi is not marked as required, do not try to set it as an iceberg identifier field id

## Brief change log

- check if record key fields are all required

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

