### PR TITLE
fix: use Schema.Field.NULL_DEFAULT_VALUE instead of JsonProperties.NULL_VALUE

### DIFF
--- a/core/src/main/java/io/onetable/avro/AvroSchemaConverter.java
+++ b/core/src/main/java/io/onetable/avro/AvroSchemaConverter.java
@@ -287,7 +287,7 @@ public class AvroSchemaConverter {
   }
 
   private static Object getDefaultValue(Schema.Field avroField) {
-    return Schema.Field.NULL_VALUE.equals(avroField.defaultVal())
+    return Schema.Field.NULL_DEFAULT_VALUE.equals(avroField.defaultVal())
         ? OneField.Constants.NULL_DEFAULT_VALUE
         : avroField.defaultVal();
   }


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

Look like we should use Schema.Field.NULL_DEFAULT_VALUE instead of JsonProperties.NULL_VALUE 

## Brief change log
fix: use Schema.Field.NULL_DEFAULT_VALUE instead of JsonProperties.NULL_VALUE

## Verify this pull request

