### PR TITLE
fix: use Schema.Field.NULL_DEFAULT_VALUE instead of JsonProperties.NULL_VALUE

### DIFF
--- a/core/src/main/java/io/onetable/avro/AvroSchemaConverter.java
+++ b/core/src/main/java/io/onetable/avro/AvroSchemaConverter.java
@@ -287,7 +287,7 @@ public class AvroSchemaConverter {
   }
 
   private static Object getDefaultValue(Schema.Field avroField) {
-    return Schema.Field.NULL_VALUE.equals(avroField.defaultVal())
+    return Schema.Field.NULL_DEFAULT_VALUE.equals(avroField.defaultVal())
         ? OneField.Constants.NULL_DEFAULT_VALUE
         : avroField.defaultVal();
   }
@@ -324,7 +324,7 @@ public class AvroSchemaConverter {
                                 getFullyQualifiedPath(currentPath, field.getName())),
                             field.getSchema().getComment(),
                             OneField.Constants.NULL_DEFAULT_VALUE == field.getDefaultValue()
-                                ? Schema.Field.NULL_VALUE
+                                ? Schema.Field.NULL_DEFAULT_VALUE
                                 : field.getDefaultValue()))
                 .collect(toList(oneSchema.getFields().size()));
         return finalizeSchema(


### PR DESCRIPTION
## *Important Read*
- *Please ensure the GitHub issue is mentioned at the beginning of the PR*

## What is the purpose of the pull request

JsonProperties.NULL_VALUE is checking whether the actual value of the field is null.

If we check to where default value is null,  we should use NULL_DEFAULT_VALUE

## Brief change log

fix: use Schema.Field.NULL_DEFAULT_VALUE instead of JsonProperties.NULL_VALUE

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end.*
- *Added HudiSchemaEvolutionTest to verify the change.*
- *Manually verified the change by running a job locally.*
