### PR TITLE
#285 Exclude netty.io:netty-tcnative-classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,10 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-tcnative-classes</artifactId>
+                    </exclusion>
                 </exclusions>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
#285 Build failure trying to pull in transitive dependency from spark-core. 
This PR removes the tcnative classes.

## What is the purpose of the pull request
Fixes local build failure.

## Brief change log
Updated pom.xml with exclusion in spark-core dependency.

## Verify this pull request

This pull request is already covered by existing tests, such as building and running tests.
I also ensured that the tcnative classes existing in the packaged shaded jars even with the exclusion in the spark-core dependency.
