### PR TITLE
Add getSchema() to SourceClient interface

### DIFF
--- a/api/src/main/java/io/onetable/spi/extractor/SourceClient.java
+++ b/api/src/main/java/io/onetable/spi/extractor/SourceClient.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 
 import io.onetable.model.*;
 import io.onetable.model.CommitsBacklog;
+import io.onetable.model.schema.OneSchema;
 import io.onetable.model.schema.SchemaCatalog;
 
 /**
@@ -47,6 +48,14 @@ public interface SourceClient<COMMIT> extends Closeable {
    * @return the schema catalog
    */
   SchemaCatalog getSchemaCatalog(OneTable table, COMMIT commit);
+
+  /**
+   * Extracts the {@link OneSchema} as of the latest state.
+   *
+   * @param table the current state of the table
+   * @return
+   */
+  OneSchema getSchema(OneTable table);
 
   /**
    * Extracts the {@link OneSnapshot} as of latest state.

--- a/core/src/main/java/io/onetable/delta/DeltaSourceClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaSourceClient.java
@@ -91,6 +91,11 @@ public class DeltaSourceClient implements SourceClient<Long> {
   }
 
   @Override
+  public OneSchema getSchema(OneTable table) {
+    return table.getReadSchema();
+  }
+
+  @Override
   public OneSnapshot getCurrentSnapshot() {
     DeltaLog deltaLog = DeltaLog.forTable(sparkSession, basePath);
     Snapshot snapshot = deltaLog.snapshot();

--- a/core/src/main/java/io/onetable/hudi/HudiClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiClient.java
@@ -49,6 +49,7 @@ import com.google.common.collect.PeekingIterator;
 import io.onetable.exception.OneIOException;
 import io.onetable.model.*;
 import io.onetable.model.CommitsBacklog;
+import io.onetable.model.schema.OneSchema;
 import io.onetable.model.schema.SchemaCatalog;
 import io.onetable.spi.extractor.SourceClient;
 
@@ -80,6 +81,11 @@ public class HudiClient implements SourceClient<HoodieInstant> {
   @Override
   public SchemaCatalog getSchemaCatalog(OneTable table, HoodieInstant commit) {
     return HudiSchemaCatalogExtractor.catalogWithTableSchema(table);
+  }
+
+  @Override
+  public OneSchema getSchema(OneTable table) {
+    return table.getReadSchema();
   }
 
   @Override

--- a/core/src/main/java/io/onetable/iceberg/IcebergSourceClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSourceClient.java
@@ -130,6 +130,13 @@ public class IcebergSourceClient implements SourceClient<Snapshot> {
   }
 
   @Override
+  public OneSchema getSchema(OneTable table) {
+    Table iceTable = getSourceTable();
+    IcebergSchemaExtractor schemaExtractor = IcebergSchemaExtractor.getInstance();
+    return schemaExtractor.fromIceberg(iceTable.schema());
+  }
+
+  @Override
   public OneSnapshot getCurrentSnapshot() {
     Table iceTable = getSourceTable();
 

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
@@ -309,6 +309,17 @@ class TestIcebergSourceClient {
     // validatePendingCommits(catalogSales, snapshot1, snapshot2, snapshot3b, snapshot4);
   }
 
+  @Test
+  public void getSchema(@TempDir Path workingDir) throws IOException {
+    Table catalogSales = createTestTableWithData(workingDir.toString());
+    PerTableConfig sourceTableConfig = getPerTableConfig(catalogSales);
+    IcebergSourceClient client = clientProvider.getSourceClientInstance(sourceTableConfig);
+    IcebergSourceClient spyClient = spy(client);
+    OneSchema schema = spyClient.getSchema(null);
+    Assertions.assertNotNull(schema);
+    validateSchema(schema, catalogSales.schema());
+  }
+
   private void validatePendingCommits(Table table, Snapshot lastSync, Snapshot... snapshots) {
     InstantsForIncrementalSync instant =
         InstantsForIncrementalSync.builder()


### PR DESCRIPTION
Addresses #77 

This change adds getSchema() method to SourceClient interface

- *Add getSchema() method to SourceClient*
- *Added unit tests for getSchema() in TestIcebergSourceClient*

