### PR TITLE
#300 - Change the Enum for TableFormat to String constants for future extens…

### DIFF
--- a/api/src/main/java/io/onetable/model/OneTable.java
+++ b/api/src/main/java/io/onetable/model/OneTable.java
@@ -27,7 +27,6 @@ import lombok.Value;
 import io.onetable.model.schema.OnePartitionField;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.storage.DataLayoutStrategy;
-import io.onetable.model.storage.TableFormat;
 
 /**
  * Represents a reference to the table in the format {@link #tableFormat}.
@@ -40,7 +39,7 @@ public class OneTable {
   // name of the table
   String name;
   // table format the table currently has data in
-  TableFormat tableFormat;
+  String tableFormat;
   // Schema to use for reading the table
   OneSchema readSchema;
   // Data layout strategy

--- a/api/src/main/java/io/onetable/model/storage/TableFormat.java
+++ b/api/src/main/java/io/onetable/model/storage/TableFormat.java
@@ -23,8 +23,12 @@ package io.onetable.model.storage;
  *
  * @since 0.1
  */
-public enum TableFormat {
-  HUDI,
-  ICEBERG,
-  DELTA
+public class TableFormat {
+  public static final String HUDI = "HUDI";
+  public static final String ICEBERG = "ICEBERG";
+  public static final String DELTA = "DELTA";
+
+  public static String[] values() {
+    return new String[] {"HUDI", "ICEBERG", "DELTA"};
+  }
 }

--- a/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
+++ b/api/src/main/java/io/onetable/spi/sync/TableFormatSync.java
@@ -38,7 +38,6 @@ import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
 import io.onetable.model.OneTableMetadata;
 import io.onetable.model.TableChange;
-import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
 import io.onetable.model.sync.SyncResult;
 
@@ -59,10 +58,10 @@ public class TableFormatSync {
    * @param snapshot the snapshot to sync
    * @return the result of the sync process
    */
-  public Map<TableFormat, SyncResult> syncSnapshot(
+  public Map<String, SyncResult> syncSnapshot(
       Collection<TargetClient> targetClients, OneSnapshot snapshot) {
     Instant startTime = Instant.now();
-    Map<TableFormat, SyncResult> results = new HashMap<>();
+    Map<String, SyncResult> results = new HashMap<>();
     for (TargetClient targetClient : targetClients) {
       try {
         OneTable oneTable = snapshot.getTable();
@@ -91,10 +90,10 @@ public class TableFormatSync {
    * @param changes the changes from the source table format that need to be applied
    * @return the results of trying to sync each change
    */
-  public Map<TableFormat, List<SyncResult>> syncChanges(
+  public Map<String, List<SyncResult>> syncChanges(
       Map<TargetClient, OneTableMetadata> targetClientWithMetadata,
       IncrementalTableChanges changes) {
-    Map<TableFormat, List<SyncResult>> results = new HashMap<>();
+    Map<String, List<SyncResult>> results = new HashMap<>();
     Set<TargetClient> clientsWithFailures = new HashSet<>();
     while (changes.getTableChanges().hasNext()) {
       TableChange change = changes.getTableChanges().next();

--- a/api/src/main/java/io/onetable/spi/sync/TargetClient.java
+++ b/api/src/main/java/io/onetable/spi/sync/TargetClient.java
@@ -27,7 +27,6 @@ import io.onetable.model.schema.OnePartitionField;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.storage.OneDataFilesDiff;
 import io.onetable.model.storage.OneFileGroup;
-import io.onetable.model.storage.TableFormat;
 
 /** A client that provides the major functionality for syncing changes to a target system. */
 public interface TargetClient {
@@ -83,6 +82,6 @@ public interface TargetClient {
   /** Returns the onetable metadata persisted in the target */
   Optional<OneTableMetadata> getTableMetadata();
 
-  /** Returns the {@link io.onetable.model.storage.TableFormat} the client syncs to */
-  TableFormat getTableFormat();
+  /** Returns the TableFormat name the client syncs to */
+  String getTableFormat();
 }

--- a/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
+++ b/api/src/test/java/io/onetable/spi/sync/TestTableFormatSync.java
@@ -80,7 +80,7 @@ public class TestTableFormatSync {
     when(mockTargetClient1.getTableFormat()).thenReturn(TableFormat.ICEBERG);
     when(mockTargetClient2.getTableFormat()).thenReturn(TableFormat.DELTA);
     doThrow(new RuntimeException("Failure")).when(mockTargetClient1).beginSync(startingTableState);
-    Map<TableFormat, SyncResult> result =
+    Map<String, SyncResult> result =
         TableFormatSync.getInstance()
             .syncSnapshot(Arrays.asList(mockTargetClient1, mockTargetClient2), snapshot);
 
@@ -153,7 +153,7 @@ public class TestTableFormatSync {
         mockTargetClient2,
         OneTableMetadata.of(Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList()));
 
-    Map<TableFormat, List<SyncResult>> result =
+    Map<String, List<SyncResult>> result =
         TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
 
     assertEquals(2, result.size());
@@ -243,7 +243,7 @@ public class TestTableFormatSync {
         OneTableMetadata.of(
             tableChange1.getTableAsOfChange().getLatestCommitTime(), Collections.emptyList()));
 
-    Map<TableFormat, List<SyncResult>> result =
+    Map<String, List<SyncResult>> result =
         TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
 
     assertEquals(2, result.size());
@@ -316,7 +316,7 @@ public class TestTableFormatSync {
         mockTargetClient2,
         OneTableMetadata.of(Instant.now().minus(1, ChronoUnit.HOURS), Collections.emptyList()));
 
-    Map<TableFormat, List<SyncResult>> result =
+    Map<String, List<SyncResult>> result =
         TableFormatSync.getInstance().syncChanges(clientWithMetadata, incrementalTableChanges);
     assertEquals(1, result.size());
     List<SyncResult> client2Results = result.get(TableFormat.DELTA);

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -143,7 +143,6 @@ public class OneTableClient {
     return syncResultsMerged.entrySet().stream()
         .filter(entry -> entry.getValue().getStatus().getStatusCode() == statusCode)
         .map(Map.Entry::getKey)
-        .map(String::valueOf)
         .collect(Collectors.joining(","));
   }
 

--- a/core/src/main/java/io/onetable/client/PerTableConfig.java
+++ b/core/src/main/java/io/onetable/client/PerTableConfig.java
@@ -32,7 +32,6 @@ import com.google.common.base.Preconditions;
 
 import io.onetable.hudi.HudiSourceConfig;
 import io.onetable.iceberg.IcebergCatalogConfig;
-import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
 
 /** Represents input configuration to the sync process. */
@@ -77,7 +76,7 @@ public class PerTableConfig {
   @Nonnull HudiSourceConfig hudiSourceConfig;
 
   /** List of table formats to sync. */
-  @Nonnull List<TableFormat> targetTableFormats;
+  @Nonnull List<String> targetTableFormats;
 
   /** Configuration options for integrating with an existing Iceberg Catalog (optional) */
   IcebergCatalogConfig icebergCatalogConfig;
@@ -107,7 +106,7 @@ public class PerTableConfig {
       @NonNull String tableName,
       String[] namespace,
       HudiSourceConfig hudiSourceConfig,
-      @NonNull List<TableFormat> targetTableFormats,
+      @NonNull List<String> targetTableFormats,
       IcebergCatalogConfig icebergCatalogConfig,
       SyncMode syncMode,
       Integer targetMetadataRetentionInHours) {

--- a/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
+++ b/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
@@ -18,6 +18,10 @@
  
 package io.onetable.client;
 
+import static io.onetable.model.storage.TableFormat.DELTA;
+import static io.onetable.model.storage.TableFormat.HUDI;
+import static io.onetable.model.storage.TableFormat.ICEBERG;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -28,10 +32,6 @@ import io.onetable.exception.NotSupportedException;
 import io.onetable.hudi.HudiTargetClient;
 import io.onetable.iceberg.IcebergClient;
 import io.onetable.spi.sync.TargetClient;
-
-import static io.onetable.model.storage.TableFormat.DELTA;
-import static io.onetable.model.storage.TableFormat.HUDI;
-import static io.onetable.model.storage.TableFormat.ICEBERG;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TableFormatClientFactory {

--- a/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
+++ b/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
@@ -27,7 +27,6 @@ import io.onetable.delta.DeltaClient;
 import io.onetable.exception.NotSupportedException;
 import io.onetable.hudi.HudiTargetClient;
 import io.onetable.iceberg.IcebergClient;
-import io.onetable.model.storage.TableFormat;
 import io.onetable.spi.sync.TargetClient;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -39,13 +38,13 @@ public class TableFormatClientFactory {
   }
 
   public TargetClient createForFormat(
-      TableFormat tableFormat, PerTableConfig perTableConfig, Configuration configuration) {
+      String tableFormat, PerTableConfig perTableConfig, Configuration configuration) {
     switch (tableFormat) {
-      case ICEBERG:
+      case "ICEBERG":
         return new IcebergClient(perTableConfig, configuration);
-      case DELTA:
+      case "DELTA":
         return new DeltaClient(perTableConfig, configuration);
-      case HUDI:
+      case "HUDI":
         return new HudiTargetClient(perTableConfig, configuration);
       default:
         throw new NotSupportedException("Target format is not yet supported: " + tableFormat);

--- a/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
+++ b/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
@@ -29,6 +29,10 @@ import io.onetable.hudi.HudiTargetClient;
 import io.onetable.iceberg.IcebergClient;
 import io.onetable.spi.sync.TargetClient;
 
+import static io.onetable.model.storage.TableFormat.DELTA;
+import static io.onetable.model.storage.TableFormat.HUDI;
+import static io.onetable.model.storage.TableFormat.ICEBERG;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TableFormatClientFactory {
   private static final TableFormatClientFactory INSTANCE = new TableFormatClientFactory();
@@ -40,11 +44,11 @@ public class TableFormatClientFactory {
   public TargetClient createForFormat(
       String tableFormat, PerTableConfig perTableConfig, Configuration configuration) {
     switch (tableFormat) {
-      case "ICEBERG":
+      case ICEBERG:
         return new IcebergClient(perTableConfig, configuration);
-      case "DELTA":
+      case DELTA:
         return new DeltaClient(perTableConfig, configuration);
-      case "HUDI":
+      case HUDI:
         return new HudiTargetClient(perTableConfig, configuration);
       default:
         throw new NotSupportedException("Target format is not yet supported: " + tableFormat);

--- a/core/src/main/java/io/onetable/delta/DeltaClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClient.java
@@ -172,7 +172,7 @@ public class DeltaClient implements TargetClient {
   }
 
   @Override
-  public TableFormat getTableFormat() {
+  public String getTableFormat() {
     return TableFormat.DELTA;
   }
 

--- a/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
@@ -289,7 +289,7 @@ public class HudiTargetClient implements TargetClient {
   }
 
   @Override
-  public TableFormat getTableFormat() {
+  public String getTableFormat() {
     return TableFormat.HUDI;
   }
 

--- a/core/src/main/java/io/onetable/iceberg/IcebergClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergClient.java
@@ -221,7 +221,7 @@ public class IcebergClient implements TargetClient {
   }
 
   @Override
-  public TableFormat getTableFormat() {
+  public String getTableFormat() {
     return TableFormat.ICEBERG;
   }
 

--- a/core/src/test/java/io/onetable/GenericTable.java
+++ b/core/src/test/java/io/onetable/GenericTable.java
@@ -18,6 +18,10 @@
  
 package io.onetable;
 
+import static io.onetable.model.storage.TableFormat.DELTA;
+import static io.onetable.model.storage.TableFormat.HUDI;
+import static io.onetable.model.storage.TableFormat.ICEBERG;
+
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -27,10 +31,6 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 
 import org.apache.hudi.common.model.HoodieTableType;
-
-import static io.onetable.model.storage.TableFormat.DELTA;
-import static io.onetable.model.storage.TableFormat.HUDI;
-import static io.onetable.model.storage.TableFormat.ICEBERG;
 
 public interface GenericTable<T, Q> extends AutoCloseable {
   // A list of values for the level field which serves as a basic field to partition on for tests

--- a/core/src/test/java/io/onetable/GenericTable.java
+++ b/core/src/test/java/io/onetable/GenericTable.java
@@ -28,6 +28,10 @@ import org.apache.spark.sql.SparkSession;
 
 import org.apache.hudi.common.model.HoodieTableType;
 
+import static io.onetable.model.storage.TableFormat.DELTA;
+import static io.onetable.model.storage.TableFormat.HUDI;
+import static io.onetable.model.storage.TableFormat.ICEBERG;
+
 public interface GenericTable<T, Q> extends AutoCloseable {
   // A list of values for the level field which serves as a basic field to partition on for tests
   List<String> LEVEL_VALUES = Arrays.asList("INFO", "WARN", "ERROR");
@@ -70,13 +74,13 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       String sourceFormat,
       boolean isPartitioned) {
     switch (sourceFormat) {
-      case "HUDI":
+      case HUDI:
         return TestSparkHudiTable.forStandardSchemaAndPartitioning(
             tableName, tempDir, jsc, isPartitioned);
-      case "DELTA":
+      case DELTA:
         return TestSparkDeltaTable.forStandardSchemaAndPartitioning(
             tableName, tempDir, sparkSession, isPartitioned ? "level" : null);
-      case "ICEBERG":
+      case ICEBERG:
         return TestIcebergTable.forStandardSchemaAndPartitioning(
             tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
       default:
@@ -92,13 +96,13 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       String sourceFormat,
       boolean isPartitioned) {
     switch (sourceFormat) {
-      case "HUDI":
+      case HUDI:
         return TestSparkHudiTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, tempDir, jsc, isPartitioned);
-      case "DELTA":
+      case DELTA:
         return TestSparkDeltaTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, tempDir, sparkSession, isPartitioned ? "level" : null);
-      case "ICEBERG":
+      case ICEBERG:
         return TestIcebergTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
       default:
@@ -113,7 +117,7 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       String sourceFormat,
       String partitionConfig) {
     switch (sourceFormat) {
-      case "HUDI":
+      case HUDI:
         return TestSparkHudiTable.forStandardSchema(
             tableName, tempDir, jsc, partitionConfig, HoodieTableType.COPY_ON_WRITE);
       default:

--- a/core/src/test/java/io/onetable/GenericTable.java
+++ b/core/src/test/java/io/onetable/GenericTable.java
@@ -28,8 +28,6 @@ import org.apache.spark.sql.SparkSession;
 
 import org.apache.hudi.common.model.HoodieTableType;
 
-import io.onetable.model.storage.TableFormat;
-
 public interface GenericTable<T, Q> extends AutoCloseable {
   // A list of values for the level field which serves as a basic field to partition on for tests
   List<String> LEVEL_VALUES = Arrays.asList("INFO", "WARN", "ERROR");
@@ -69,16 +67,16 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       Path tempDir,
       SparkSession sparkSession,
       JavaSparkContext jsc,
-      TableFormat sourceFormat,
+      String sourceFormat,
       boolean isPartitioned) {
     switch (sourceFormat) {
-      case HUDI:
+      case "HUDI":
         return TestSparkHudiTable.forStandardSchemaAndPartitioning(
             tableName, tempDir, jsc, isPartitioned);
-      case DELTA:
+      case "DELTA":
         return TestSparkDeltaTable.forStandardSchemaAndPartitioning(
             tableName, tempDir, sparkSession, isPartitioned ? "level" : null);
-      case ICEBERG:
+      case "ICEBERG":
         return TestIcebergTable.forStandardSchemaAndPartitioning(
             tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
       default:
@@ -91,16 +89,16 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       Path tempDir,
       SparkSession sparkSession,
       JavaSparkContext jsc,
-      TableFormat sourceFormat,
+      String sourceFormat,
       boolean isPartitioned) {
     switch (sourceFormat) {
-      case HUDI:
+      case "HUDI":
         return TestSparkHudiTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, tempDir, jsc, isPartitioned);
-      case DELTA:
+      case "DELTA":
         return TestSparkDeltaTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, tempDir, sparkSession, isPartitioned ? "level" : null);
-      case ICEBERG:
+      case "ICEBERG":
         return TestIcebergTable.forSchemaWithAdditionalColumnsAndPartitioning(
             tableName, isPartitioned ? "level" : null, tempDir, jsc.hadoopConfiguration());
       default:
@@ -112,10 +110,10 @@ public interface GenericTable<T, Q> extends AutoCloseable {
       String tableName,
       Path tempDir,
       JavaSparkContext jsc,
-      TableFormat sourceFormat,
+      String sourceFormat,
       String partitionConfig) {
     switch (sourceFormat) {
-      case HUDI:
+      case "HUDI":
         return TestSparkHudiTable.forStandardSchema(
             tableName, tempDir, jsc, partitionConfig, HoodieTableType.COPY_ON_WRITE);
       default:

--- a/core/src/test/java/io/onetable/ITOneTableClient.java
+++ b/core/src/test/java/io/onetable/ITOneTableClient.java
@@ -128,8 +128,7 @@ public class ITOneTableClient {
 
   private static Stream<Arguments> generateTestParametersForFormatsSyncModesAndPartitioning() {
     List<Arguments> arguments = new ArrayList<>();
-    for (String sourceTableFormat :
-        Arrays.asList(HUDI, DELTA, ICEBERG)) {
+    for (String sourceTableFormat : Arrays.asList(HUDI, DELTA, ICEBERG)) {
       for (SyncMode syncMode : SyncMode.values()) {
         for (boolean isPartitioned : new boolean[] {true, false}) {
           arguments.add(Arguments.of(sourceTableFormat, syncMode, isPartitioned));
@@ -339,23 +338,13 @@ public class ITOneTableClient {
           Collections.singletonMap("hoodie.datasource.query.type", "read_optimized");
       // Because compaction is not completed yet and read optimized query, there are 100 records.
       checkDatasetEquivalence(
-          HUDI,
-          table,
-          sourceHudiOptions,
-          targetTableFormats,
-          Collections.emptyMap(),
-          100);
+          HUDI, table, sourceHudiOptions, targetTableFormats, Collections.emptyMap(), 100);
 
       table.insertRecords(50, true);
       oneTableClient.sync(perTableConfig, sourceClientProvider);
       // Because compaction is not completed yet and read optimized query, there are 150 records.
       checkDatasetEquivalence(
-          HUDI,
-          table,
-          sourceHudiOptions,
-          targetTableFormats,
-          Collections.emptyMap(),
-          150);
+          HUDI, table, sourceHudiOptions, targetTableFormats, Collections.emptyMap(), 150);
 
       table.completeScheduledCompaction(scheduledCompactionInstant);
       oneTableClient.sync(perTableConfig, sourceClientProvider);
@@ -440,25 +429,13 @@ public class ITOneTableClient {
     return Stream.of(
         Arguments.of(
             buildArgsForPartition(
-                HUDI,
-                Arrays.asList(ICEBERG, DELTA),
-                "level:SIMPLE",
-                "level:VALUE",
-                levelFilter)),
+                HUDI, Arrays.asList(ICEBERG, DELTA), "level:SIMPLE", "level:VALUE", levelFilter)),
         Arguments.of(
             buildArgsForPartition(
-                DELTA,
-                Arrays.asList(ICEBERG, HUDI),
-                null,
-                "level:VALUE",
-                levelFilter)),
+                DELTA, Arrays.asList(ICEBERG, HUDI), null, "level:VALUE", levelFilter)),
         Arguments.of(
             buildArgsForPartition(
-                ICEBERG,
-                Arrays.asList(DELTA, HUDI),
-                null,
-                "level:VALUE",
-                levelFilter)),
+                ICEBERG, Arrays.asList(DELTA, HUDI), null, "level:VALUE", levelFilter)),
         Arguments.of(
             // Delta Lake does not currently support nested partition columns
             buildArgsForPartition(
@@ -555,19 +532,15 @@ public class ITOneTableClient {
 
       OneTableClient oneTableClient = new OneTableClient(jsc.hadoopConfiguration());
       oneTableClient.sync(perTableConfigIceberg, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(ICEBERG), 100);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(ICEBERG), 100);
       oneTableClient.sync(perTableConfigDelta, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(DELTA), 100);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(DELTA), 100);
 
       table.insertRecords(100, true);
       oneTableClient.sync(perTableConfigIceberg, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(ICEBERG), 200);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(ICEBERG), 200);
       oneTableClient.sync(perTableConfigDelta, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(DELTA), 200);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(DELTA), 200);
     }
   }
 
@@ -598,14 +571,12 @@ public class ITOneTableClient {
       OneTableClient oneTableClient = new OneTableClient(jsc.hadoopConfiguration());
       // sync iceberg only
       oneTableClient.sync(singleTableConfig, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(ICEBERG), 50);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(ICEBERG), 50);
       // insert more records
       table.insertRecords(50, true);
       // iceberg will be an incremental sync and delta will need to bootstrap with snapshot sync
       oneTableClient.sync(dualTableConfig, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Arrays.asList(ICEBERG, DELTA), 100);
+      checkDatasetEquivalence(HUDI, table, Arrays.asList(ICEBERG, DELTA), 100);
 
       // insert more records
       table.insertRecords(50, true);
@@ -613,15 +584,13 @@ public class ITOneTableClient {
       table.insertRecords(50, true);
       // incremental sync for two commits for iceberg only
       oneTableClient.sync(singleTableConfig, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(ICEBERG), 200);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(ICEBERG), 200);
 
       // insert more records
       table.insertRecords(50, true);
       // incremental sync for one commit for iceberg and three commits for delta
       oneTableClient.sync(dualTableConfig, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Arrays.asList(ICEBERG, DELTA), 250);
+      checkDatasetEquivalence(HUDI, table, Arrays.asList(ICEBERG, DELTA), 250);
     }
   }
 
@@ -656,8 +625,7 @@ public class ITOneTableClient {
           Paths.get(URI.create(icebergTable.snapshot(previousSnapshotId).manifestListLocation())));
       table.insertRows(10);
       oneTableClient.sync(perTableConfig, sourceClientProvider);
-      checkDatasetEquivalence(
-          HUDI, table, Collections.singletonList(ICEBERG), 50);
+      checkDatasetEquivalence(HUDI, table, Collections.singletonList(ICEBERG), 50);
     }
   }
 

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -76,7 +76,7 @@ public class TestOneTableClient {
     OneSnapshot oneSnapshot = buildOneSnapshot(oneTable, "v1");
     Instant instantBeforeHour = Instant.now().minus(Duration.ofHours(1));
     SyncResult syncResult = buildSyncResult(syncMode, instantBeforeHour);
-    Map<TableFormat, SyncResult> perTableResults = new HashMap<>();
+    Map<String, SyncResult> perTableResults = new HashMap<>();
     perTableResults.put(TableFormat.ICEBERG, syncResult);
     perTableResults.put(TableFormat.DELTA, syncResult);
     PerTableConfig perTableConfig =
@@ -95,8 +95,7 @@ public class TestOneTableClient {
         .thenReturn(perTableResults);
     OneTableClient oneTableClient =
         new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
-    Map<TableFormat, SyncResult> result =
-        oneTableClient.sync(perTableConfig, mockSourceClientProvider);
+    Map<String, SyncResult> result = oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(perTableResults, result);
   }
 
@@ -164,7 +163,7 @@ public class TestOneTableClient {
     List<SyncResult> deltaSyncResults = buildSyncResults(Arrays.asList(instantAt8, instantAt2));
     IncrementalTableChanges incrementalTableChanges =
         IncrementalTableChanges.builder().tableChanges(tableChanges.iterator()).build();
-    Map<TableFormat, List<SyncResult>> allResults = new HashMap<>();
+    Map<String, List<SyncResult>> allResults = new HashMap<>();
     allResults.put(TableFormat.ICEBERG, icebergSyncResults);
     allResults.put(TableFormat.DELTA, deltaSyncResults);
     Map<TargetClient, OneTableMetadata> clientToMetadata = new HashMap<>();
@@ -173,13 +172,12 @@ public class TestOneTableClient {
     when(tableFormatSync.syncChanges(
             eq(clientToMetadata), argThat(matches(incrementalTableChanges))))
         .thenReturn(allResults);
-    Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
+    Map<String, SyncResult> expectedSyncResult = new HashMap<>();
     expectedSyncResult.put(TableFormat.ICEBERG, getLastSyncResult(icebergSyncResults));
     expectedSyncResult.put(TableFormat.DELTA, getLastSyncResult(deltaSyncResults));
     OneTableClient oneTableClient =
         new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
-    Map<TableFormat, SyncResult> result =
-        oneTableClient.sync(perTableConfig, mockSourceClientProvider);
+    Map<String, SyncResult> result = oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(expectedSyncResult, result);
   }
 
@@ -190,7 +188,7 @@ public class TestOneTableClient {
     Instant instantBeforeHour = Instant.now().minus(Duration.ofHours(1));
     OneSnapshot oneSnapshot = buildOneSnapshot(oneTable, "v1");
     SyncResult syncResult = buildSyncResult(syncMode, instantBeforeHour);
-    Map<TableFormat, SyncResult> syncResults = new HashMap<>();
+    Map<String, SyncResult> syncResults = new HashMap<>();
     syncResults.put(TableFormat.ICEBERG, syncResult);
     syncResults.put(TableFormat.DELTA, syncResult);
     PerTableConfig perTableConfig =
@@ -220,8 +218,7 @@ public class TestOneTableClient {
         .thenReturn(syncResults);
     OneTableClient oneTableClient =
         new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
-    Map<TableFormat, SyncResult> result =
-        oneTableClient.sync(perTableConfig, mockSourceClientProvider);
+    Map<String, SyncResult> result = oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(syncResults, result);
   }
 
@@ -280,7 +277,7 @@ public class TestOneTableClient {
     Instant instantBeforeHour = Instant.now().minus(Duration.ofHours(1));
     OneSnapshot oneSnapshot = buildOneSnapshot(oneTable, "v1");
     SyncResult syncResult = buildSyncResult(syncMode, instantBeforeHour);
-    Map<TableFormat, SyncResult> snapshotResult =
+    Map<String, SyncResult> snapshotResult =
         Collections.singletonMap(TableFormat.ICEBERG, syncResult);
     when(mockSourceClient.getCurrentSnapshot()).thenReturn(oneSnapshot);
     when(tableFormatSync.syncSnapshot(
@@ -295,13 +292,12 @@ public class TestOneTableClient {
             eq(Collections.singletonMap(mockTargetClient2, targetClient2Metadata.get())),
             argThat(matches(incrementalTableChanges))))
         .thenReturn(Collections.singletonMap(TableFormat.DELTA, deltaSyncResults));
-    Map<TableFormat, SyncResult> expectedSyncResult = new HashMap<>();
+    Map<String, SyncResult> expectedSyncResult = new HashMap<>();
     expectedSyncResult.put(TableFormat.ICEBERG, syncResult);
     expectedSyncResult.put(TableFormat.DELTA, getLastSyncResult(deltaSyncResults));
     OneTableClient oneTableClient =
         new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
-    Map<TableFormat, SyncResult> result =
-        oneTableClient.sync(perTableConfig, mockSourceClientProvider);
+    Map<String, SyncResult> result = oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(expectedSyncResult, result);
   }
 
@@ -352,11 +348,10 @@ public class TestOneTableClient {
                         .build()))))
         .thenReturn(Collections.emptyMap());
     // Iceberg and Delta have no commits to sync
-    Map<TableFormat, SyncResult> expectedSyncResult = Collections.emptyMap();
+    Map<String, SyncResult> expectedSyncResult = Collections.emptyMap();
     OneTableClient oneTableClient =
         new OneTableClient(mockConf, mockTableFormatClientFactory, tableFormatSync);
-    Map<TableFormat, SyncResult> result =
-        oneTableClient.sync(perTableConfig, mockSourceClientProvider);
+    Map<String, SyncResult> result = oneTableClient.sync(perTableConfig, mockSourceClientProvider);
     assertEquals(expectedSyncResult, result);
   }
 
@@ -398,8 +393,7 @@ public class TestOneTableClient {
     return Instant.now().minus(Duration.ofMinutes(n));
   }
 
-  private PerTableConfig getPerTableConfig(
-      List<TableFormat> targetTableFormats, SyncMode syncMode) {
+  private PerTableConfig getPerTableConfig(List<String> targetTableFormats, SyncMode syncMode) {
     return PerTableConfig.builder()
         .tableName(getTableName())
         .tableBasePath("/tmp/doesnt/matter")

--- a/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
+++ b/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
@@ -646,7 +646,7 @@ public class ITDeltaSourceClient {
   private static void validateTable(
       OneTable oneTable,
       String tableName,
-      TableFormat tableFormat,
+      String tableFormat,
       OneSchema readSchema,
       DataLayoutStrategy dataLayoutStrategy,
       String basePath,

--- a/hudi-support/extensions/src/main/java/io/onetable/hudi/sync/OneTableSyncTool.java
+++ b/hudi-support/extensions/src/main/java/io/onetable/hudi/sync/OneTableSyncTool.java
@@ -39,7 +39,6 @@ import io.onetable.client.PerTableConfig;
 import io.onetable.hudi.HudiSourceClientProvider;
 import io.onetable.hudi.HudiSourceConfig;
 import io.onetable.model.schema.PartitionTransformType;
-import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
 import io.onetable.model.sync.SyncResult;
 
@@ -57,9 +56,9 @@ public class OneTableSyncTool extends HoodieSyncTool {
 
   @Override
   public void syncHoodieTable() {
-    List<TableFormat> formatsToSync =
+    List<String> formatsToSync =
         Arrays.stream(config.getString(OneTableSyncConfig.ONE_TABLE_FORMATS).split(","))
-            .map(format -> TableFormat.valueOf(format.toUpperCase()))
+            .map(format -> String.valueOf(format.toUpperCase()))
             .collect(Collectors.toList());
     String basePath = config.getString(HoodieSyncConfig.META_SYNC_BASE_PATH);
     String tableName = config.getString(HoodieTableConfig.HOODIE_TABLE_NAME_KEY);
@@ -76,7 +75,7 @@ public class OneTableSyncTool extends HoodieSyncTool {
             .targetMetadataRetentionInHours(
                 config.getInt(OneTableSyncConfig.ONE_TABLE_TARGET_METADATA_RETENTION_HOURS))
             .build();
-    Map<TableFormat, SyncResult> results =
+    Map<String, SyncResult> results =
         new OneTableClient(hadoopConf).sync(perTableConfig, hudiSourceClientProvider);
     String failingFormats =
         results.entrySet().stream()

--- a/hudi-support/extensions/src/main/java/io/onetable/hudi/sync/OneTableSyncTool.java
+++ b/hudi-support/extensions/src/main/java/io/onetable/hudi/sync/OneTableSyncTool.java
@@ -58,7 +58,7 @@ public class OneTableSyncTool extends HoodieSyncTool {
   public void syncHoodieTable() {
     List<String> formatsToSync =
         Arrays.stream(config.getString(OneTableSyncConfig.ONE_TABLE_FORMATS).split(","))
-            .map(format -> String.valueOf(format.toUpperCase()))
+            .map(format -> format.toUpperCase())
             .collect(Collectors.toList());
     String basePath = config.getString(HoodieSyncConfig.META_SYNC_BASE_PATH);
     String tableName = config.getString(HoodieTableConfig.HOODIE_TABLE_NAME_KEY);

--- a/utilities/src/main/java/io/onetable/utilities/RunSync.java
+++ b/utilities/src/main/java/io/onetable/utilities/RunSync.java
@@ -142,7 +142,7 @@ public class RunSync {
     sourceClientProvider.init(hadoopConf, sourceClientConfig.configuration);
 
     List<String> tableFormatList =
-        datasetConfig.getTargetFormats().stream().map(String::valueOf).collect(Collectors.toList());
+        datasetConfig.getTargetFormats();
     OneTableClient client = new OneTableClient(hadoopConf);
     for (DatasetConfig.Table table : datasetConfig.getDatasets()) {
       log.info(

--- a/utilities/src/main/java/io/onetable/utilities/RunSync.java
+++ b/utilities/src/main/java/io/onetable/utilities/RunSync.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
@@ -141,8 +140,7 @@ public class RunSync {
         ReflectionUtils.createInstanceOfClass(sourceProviderClass);
     sourceClientProvider.init(hadoopConf, sourceClientConfig.configuration);
 
-    List<String> tableFormatList =
-        datasetConfig.getTargetFormats();
+    List<String> tableFormatList = datasetConfig.getTargetFormats();
     OneTableClient client = new OneTableClient(hadoopConf);
     for (DatasetConfig.Table table : datasetConfig.getDatasets()) {
       log.info(

--- a/utilities/src/main/java/io/onetable/utilities/RunSync.java
+++ b/utilities/src/main/java/io/onetable/utilities/RunSync.java
@@ -141,10 +141,8 @@ public class RunSync {
         ReflectionUtils.createInstanceOfClass(sourceProviderClass);
     sourceClientProvider.init(hadoopConf, sourceClientConfig.configuration);
 
-    List<io.onetable.model.storage.TableFormat> tableFormatList =
-        datasetConfig.getTargetFormats().stream()
-            .map(TableFormat::valueOf)
-            .collect(Collectors.toList());
+    List<String> tableFormatList =
+        datasetConfig.getTargetFormats().stream().map(String::valueOf).collect(Collectors.toList());
     OneTableClient client = new OneTableClient(hadoopConf);
     for (DatasetConfig.Table table : datasetConfig.getDatasets()) {
       log.info(

--- a/utilities/src/test/java/io/onetable/utilities/TestRunSync.java
+++ b/utilities/src/test/java/io/onetable/utilities/TestRunSync.java
@@ -29,6 +29,10 @@ import io.onetable.iceberg.IcebergCatalogConfig;
 import io.onetable.utilities.RunSync.TableFormatClients;
 import io.onetable.utilities.RunSync.TableFormatClients.ClientConfig;
 
+import static io.onetable.model.storage.TableFormat.DELTA;
+import static io.onetable.model.storage.TableFormat.HUDI;
+import static io.onetable.model.storage.TableFormat.ICEBERG;
+
 class TestRunSync {
 
   /** Tests that the default hadoop configs are loaded. */
@@ -77,19 +81,19 @@ class TestRunSync {
     TableFormatClients clients = RunSync.loadTableFormatClientConfigs(null);
     Map<String, ClientConfig> tfClients = clients.getTableFormatsClients();
     Assertions.assertEquals(3, tfClients.size());
-    Assertions.assertNotNull(tfClients.get("DELTA"));
-    Assertions.assertNotNull(tfClients.get("HUDI"));
-    Assertions.assertNotNull(tfClients.get("ICEBERG"));
+    Assertions.assertNotNull(tfClients.get(DELTA));
+    Assertions.assertNotNull(tfClients.get(HUDI));
+    Assertions.assertNotNull(tfClients.get(ICEBERG));
 
     Assertions.assertEquals(
         "io.onetable.hudi.HudiSourceClientProvider",
-        tfClients.get("HUDI").getSourceClientProviderClass());
+        tfClients.get(HUDI).getSourceClientProviderClass());
     Assertions.assertEquals(
         "io.onetable.iceberg.IcebergTargetClient",
-        tfClients.get("ICEBERG").getTargetClientProviderClass());
+        tfClients.get(ICEBERG).getTargetClientProviderClass());
     Assertions.assertEquals(
         "io.onetable.iceberg.IcebergSourceClientProvider",
-        tfClients.get("ICEBERG").getSourceClientProviderClass());
+        tfClients.get(ICEBERG).getSourceClientProviderClass());
   }
 
   @Test
@@ -111,9 +115,9 @@ class TestRunSync {
     Assertions.assertNotNull(tfClients.get("NEW_FORMAT"));
     Assertions.assertEquals("bar", tfClients.get("NEW_FORMAT").getSourceClientProviderClass());
 
-    Assertions.assertEquals("foo", tfClients.get("HUDI").getSourceClientProviderClass());
+    Assertions.assertEquals("foo", tfClients.get(HUDI).getSourceClientProviderClass());
 
-    Map<String, String> deltaClientConfigs = tfClients.get("DELTA").getConfiguration();
+    Map<String, String> deltaClientConfigs = tfClients.get(DELTA).getConfiguration();
     Assertions.assertEquals(3, deltaClientConfigs.size());
     Assertions.assertEquals("local[4]", deltaClientConfigs.get("spark.master"));
     Assertions.assertEquals("bar", deltaClientConfigs.get("foo"));

--- a/utilities/src/test/java/io/onetable/utilities/TestRunSync.java
+++ b/utilities/src/test/java/io/onetable/utilities/TestRunSync.java
@@ -18,6 +18,10 @@
  
 package io.onetable.utilities;
 
+import static io.onetable.model.storage.TableFormat.DELTA;
+import static io.onetable.model.storage.TableFormat.HUDI;
+import static io.onetable.model.storage.TableFormat.ICEBERG;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -28,10 +32,6 @@ import org.junit.jupiter.api.Test;
 import io.onetable.iceberg.IcebergCatalogConfig;
 import io.onetable.utilities.RunSync.TableFormatClients;
 import io.onetable.utilities.RunSync.TableFormatClients.ClientConfig;
-
-import static io.onetable.model.storage.TableFormat.DELTA;
-import static io.onetable.model.storage.TableFormat.HUDI;
-import static io.onetable.model.storage.TableFormat.ICEBERG;
 
 class TestRunSync {
 


### PR DESCRIPTION
#300 to move to a String representation of the TableFormat for later extensibility improvements.

## What is the purpose of the pull request

This PR moves from a static TableFormat enum to a String representation of the TableFormat for later extensibility improvements.

## Brief change log

* Change the TableFormat enum to String constants to preserve existing references
* Change all references and maps that use TableFormat to use the appropriate String class
* Change all enum specific method references to align with the new use of String rather than enum

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.
