### PR TITLE
Introduce ServiceLoader use for TargetClients

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,6 +18,12 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
 
+        <!-- Hadoop dependencies -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/api/src/main/java/io/onetable/client/CatalogConfig.java
+++ b/api/src/main/java/io/onetable/client/CatalogConfig.java
@@ -16,19 +16,20 @@
  * limitations under the License.
  */
  
-package io.onetable.model.storage;
+package io.onetable.client;
+
+import java.util.Map;
 
 /**
- * Default constants for supported Table Formats
- *
- * @since 0.1
+ * Catologs are responsible for the management of and providing access to the metadata associated
+ * with a given set of Tables, typically within the context of a namespaces. This interface
+ * represents the configuration required to initialize a client for a particualr data engine such
+ * that it can access the necessary metadata for table conversions and semantic details.
  */
-public class TableFormat {
-  public static final String HUDI = "HUDI";
-  public static final String ICEBERG = "ICEBERG";
-  public static final String DELTA = "DELTA";
+public interface CatalogConfig {
+  String getCatalogImpl();
 
-  public static String[] values() {
-    return new String[] {"HUDI", "ICEBERG", "DELTA"};
-  }
+  String getCatalogName();
+
+  Map<String, String> getCatalogOptions();
 }

--- a/api/src/main/java/io/onetable/client/HudiSourceConfig.java
+++ b/api/src/main/java/io/onetable/client/HudiSourceConfig.java
@@ -16,19 +16,12 @@
  * limitations under the License.
  */
  
-package io.onetable.model.storage;
+package io.onetable.client;
 
-/**
- * Default constants for supported Table Formats
- *
- * @since 0.1
- */
-public class TableFormat {
-  public static final String HUDI = "HUDI";
-  public static final String ICEBERG = "ICEBERG";
-  public static final String DELTA = "DELTA";
+import io.onetable.spi.extractor.SourcePartitionSpecExtractor;
 
-  public static String[] values() {
-    return new String[] {"HUDI", "ICEBERG", "DELTA"};
-  }
+public interface HudiSourceConfig {
+  public String getPartitionSpecExtractorClass();
+
+  SourcePartitionSpecExtractor loadSourcePartitionSpecExtractor();
 }

--- a/api/src/main/java/io/onetable/client/PerTableConfig.java
+++ b/api/src/main/java/io/onetable/client/PerTableConfig.java
@@ -16,19 +16,28 @@
  * limitations under the License.
  */
  
-package io.onetable.model.storage;
+package io.onetable.client;
 
-/**
- * Default constants for supported Table Formats
- *
- * @since 0.1
- */
-public class TableFormat {
-  public static final String HUDI = "HUDI";
-  public static final String ICEBERG = "ICEBERG";
-  public static final String DELTA = "DELTA";
+import java.util.List;
 
-  public static String[] values() {
-    return new String[] {"HUDI", "ICEBERG", "DELTA"};
-  }
+import io.onetable.model.sync.SyncMode;
+
+public interface PerTableConfig {
+  int getTargetMetadataRetentionInHours();
+
+  String getTableBasePath();
+
+  String getTableDataPath();
+
+  String getTableName();
+
+  HudiSourceConfig getHudiSourceConfig();
+
+  List<String> getTargetTableFormats();
+
+  SyncMode getSyncMode();
+
+  String[] getNamespace();
+
+  CatalogConfig getIcebergCatalogConfig();
 }

--- a/api/src/main/java/io/onetable/spi/sync/TargetClient.java
+++ b/api/src/main/java/io/onetable/spi/sync/TargetClient.java
@@ -21,6 +21,9 @@ package io.onetable.spi.sync;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.hadoop.conf.Configuration;
+
+import io.onetable.client.PerTableConfig;
 import io.onetable.model.OneTable;
 import io.onetable.model.OneTableMetadata;
 import io.onetable.model.schema.OnePartitionField;
@@ -84,4 +87,7 @@ public interface TargetClient {
 
   /** Returns the TableFormat name the client syncs to */
   String getTableFormat();
+
+  /** Initializes the client with provided configuration */
+  void init(PerTableConfig perTableConfig, Configuration configuration);
 }

--- a/core/src/main/java/io/onetable/client/OneTableClient.java
+++ b/core/src/main/java/io/onetable/client/OneTableClient.java
@@ -51,8 +51,8 @@ import io.onetable.spi.sync.TableFormatSync;
 import io.onetable.spi.sync.TargetClient;
 
 /**
- * Responsible for completing the entire lifecycle of the sync process given {@link PerTableConfig}.
- * This is done in three steps,
+ * Responsible for completing the entire lifecycle of the sync process given {@link
+ * PerTableConfigImpl}. This is done in three steps,
  *
  * <ul>
  *   <li>1. Extracting snapshot {@link OneSnapshot} from the source table format.
@@ -83,7 +83,7 @@ public class OneTableClient {
    */
   public <COMMIT> Map<String, SyncResult> sync(
       PerTableConfig config, SourceClientProvider<COMMIT> sourceClientProvider) {
-    if (config.getTargetTableFormats().isEmpty()) {
+    if (config.getTargetTableFormats() == null || config.getTargetTableFormats().isEmpty()) {
       throw new IllegalArgumentException("Please provide at-least one format to sync");
     }
 

--- a/core/src/main/java/io/onetable/client/PerTableConfigImpl.java
+++ b/core/src/main/java/io/onetable/client/PerTableConfigImpl.java
@@ -139,46 +139,4 @@ public class PerTableConfigImpl implements PerTableConfig {
       return path.toString();
     }
   }
-
-  @Nonnull
-  public String getTableBasePath() {
-    return tableBasePath;
-  }
-
-  @Nonnull
-  public String getTableDataPath() {
-    return tableDataPath;
-  }
-
-  @Nonnull
-  public String getTableName() {
-    return tableName;
-  }
-
-  public String[] getNamespace() {
-    return namespace;
-  }
-
-  @Nonnull
-  public HudiSourceConfigImpl getHudiSourceConfig() {
-    return hudiSourceConfig;
-  }
-
-  @Nonnull
-  public List<String> getTargetTableFormats() {
-    return targetTableFormats;
-  }
-
-  public IcebergCatalogConfig getIcebergCatalogConfig() {
-    return icebergCatalogConfig;
-  }
-
-  @Nonnull
-  public SyncMode getSyncMode() {
-    return syncMode;
-  }
-
-  public int getTargetMetadataRetentionInHours() {
-    return targetMetadataRetentionInHours;
-  }
 }

--- a/core/src/main/java/io/onetable/client/PerTableConfigImpl.java
+++ b/core/src/main/java/io/onetable/client/PerTableConfigImpl.java
@@ -30,13 +30,13 @@ import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Preconditions;
 
-import io.onetable.hudi.HudiSourceConfig;
+import io.onetable.hudi.HudiSourceConfigImpl;
 import io.onetable.iceberg.IcebergCatalogConfig;
 import io.onetable.model.sync.SyncMode;
 
 /** Represents input configuration to the sync process. */
 @Value
-public class PerTableConfig {
+public class PerTableConfigImpl implements PerTableConfig {
   /** table base path in local file system or HDFS or object stores like S3, GCS etc. */
   @Nonnull String tableBasePath;
   /** the base path for the data folder, defaults to the tableBasePath if not specified */
@@ -73,7 +73,7 @@ public class PerTableConfig {
    *           the date string as it appears in your file paths
    *     </ul>
    */
-  @Nonnull HudiSourceConfig hudiSourceConfig;
+  @Nonnull HudiSourceConfigImpl hudiSourceConfig;
 
   /** List of table formats to sync. */
   @Nonnull List<String> targetTableFormats;
@@ -100,12 +100,12 @@ public class PerTableConfig {
   int targetMetadataRetentionInHours;
 
   @Builder
-  PerTableConfig(
+  PerTableConfigImpl(
       @NonNull String tableBasePath,
       String tableDataPath,
       @NonNull String tableName,
       String[] namespace,
-      HudiSourceConfig hudiSourceConfig,
+      HudiSourceConfigImpl hudiSourceConfig,
       @NonNull List<String> targetTableFormats,
       IcebergCatalogConfig icebergCatalogConfig,
       SyncMode syncMode,
@@ -116,7 +116,7 @@ public class PerTableConfig {
     this.tableName = tableName;
     this.namespace = namespace;
     this.hudiSourceConfig =
-        hudiSourceConfig == null ? HudiSourceConfig.builder().build() : hudiSourceConfig;
+        hudiSourceConfig == null ? HudiSourceConfigImpl.builder().build() : hudiSourceConfig;
     Preconditions.checkArgument(
         targetTableFormats.size() > 0, "Please provide at-least one format to sync");
     this.targetTableFormats = targetTableFormats;
@@ -138,5 +138,47 @@ public class PerTableConfig {
     } else {
       return path.toString();
     }
+  }
+
+  @Nonnull
+  public String getTableBasePath() {
+    return tableBasePath;
+  }
+
+  @Nonnull
+  public String getTableDataPath() {
+    return tableDataPath;
+  }
+
+  @Nonnull
+  public String getTableName() {
+    return tableName;
+  }
+
+  public String[] getNamespace() {
+    return namespace;
+  }
+
+  @Nonnull
+  public HudiSourceConfigImpl getHudiSourceConfig() {
+    return hudiSourceConfig;
+  }
+
+  @Nonnull
+  public List<String> getTargetTableFormats() {
+    return targetTableFormats;
+  }
+
+  public IcebergCatalogConfig getIcebergCatalogConfig() {
+    return icebergCatalogConfig;
+  }
+
+  @Nonnull
+  public SyncMode getSyncMode() {
+    return syncMode;
+  }
+
+  public int getTargetMetadataRetentionInHours() {
+    return targetMetadataRetentionInHours;
   }
 }

--- a/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
+++ b/core/src/main/java/io/onetable/client/TableFormatClientFactory.java
@@ -36,16 +36,32 @@ public class TableFormatClientFactory {
     return INSTANCE;
   }
 
+  /**
+   * Create a fully initialized instance of the TargetClient represented by the given Table Format
+   * name. Initialization is done with the config provideed through PerTableConfig and Conifuration
+   * params.
+   *
+   * @param tableFormat
+   * @param perTableConfig
+   * @param configuration
+   * @return
+   */
   public TargetClient createForFormat(
       String tableFormat, PerTableConfig perTableConfig, Configuration configuration) {
     TargetClient targetClient = createTargetClientForName(tableFormat);
-    if (targetClient == null) {
-      throw new NotSupportedException("Target format is not yet supported: " + tableFormat);
-    }
+
     targetClient.init(perTableConfig, configuration);
     return targetClient;
   }
 
+  /**
+   * Create an instance of the TargetClient via the default no-arg constructor. Expectation is that
+   * target client specific settings may be provided prior to the calling of TargetClient.init()
+   * which must be called prior to actual use of the target client returned by this factory method.
+   *
+   * @param tableFormatName
+   * @return
+   */
   public TargetClient createTargetClientForName(String tableFormatName) {
     ServiceLoader<TargetClient> loader = ServiceLoader.load(TargetClient.class);
     for (TargetClient target : loader) {

--- a/core/src/main/java/io/onetable/delta/DeltaClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClient.java
@@ -51,6 +51,8 @@ import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import io.onetable.client.PerTableConfig;
 import io.onetable.exception.NotSupportedException;
 import io.onetable.model.OneTable;
@@ -93,6 +95,7 @@ public class DeltaClient implements TargetClient {
         DeltaDataFileUpdatesExtractor.builder().build());
   }
 
+  @VisibleForTesting
   DeltaClient(
       String tableDataPath,
       String tableName,

--- a/core/src/main/java/io/onetable/delta/DeltaClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClient.java
@@ -80,10 +80,6 @@ public class DeltaClient implements TargetClient {
 
   public DeltaClient() {}
 
-  public DeltaClient(PerTableConfig perTableConfig, Configuration configuration) {
-    this(perTableConfig, DeltaClientUtils.buildSparkSession(configuration));
-  }
-
   public DeltaClient(PerTableConfig perTableConfig, SparkSession sparkSession) {
     this(
         perTableConfig.getTableDataPath(),

--- a/core/src/main/java/io/onetable/delta/DeltaClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClient.java
@@ -67,14 +67,16 @@ public class DeltaClient implements TargetClient {
   // gets access to generated columns.
   private static final String MIN_WRITER_VERSION = String.valueOf(4);
 
-  private final DeltaLog deltaLog;
-  private final DeltaSchemaExtractor schemaExtractor;
-  private final DeltaPartitionExtractor partitionExtractor;
-  private final DeltaDataFileUpdatesExtractor dataFileUpdatesExtractor;
+  private DeltaLog deltaLog;
+  private DeltaSchemaExtractor schemaExtractor;
+  private DeltaPartitionExtractor partitionExtractor;
+  private DeltaDataFileUpdatesExtractor dataFileUpdatesExtractor;
 
-  private final String tableName;
-  private final int logRetentionInHours;
+  private String tableName;
+  private int logRetentionInHours;
   private TransactionState transactionState;
+
+  public DeltaClient() {}
 
   public DeltaClient(PerTableConfig perTableConfig, Configuration configuration) {
     this(perTableConfig, DeltaClientUtils.buildSparkSession(configuration));
@@ -99,6 +101,25 @@ public class DeltaClient implements TargetClient {
       DeltaSchemaExtractor schemaExtractor,
       DeltaPartitionExtractor partitionExtractor,
       DeltaDataFileUpdatesExtractor dataFileUpdatesExtractor) {
+
+    _init(
+        tableDataPath,
+        tableName,
+        logRetentionInHours,
+        sparkSession,
+        schemaExtractor,
+        partitionExtractor,
+        dataFileUpdatesExtractor);
+  }
+
+  private void _init(
+      String tableDataPath,
+      String tableName,
+      int logRetentionInHours,
+      SparkSession sparkSession,
+      DeltaSchemaExtractor schemaExtractor,
+      DeltaPartitionExtractor partitionExtractor,
+      DeltaDataFileUpdatesExtractor dataFileUpdatesExtractor) {
     DeltaLog deltaLog = DeltaLog.forTable(sparkSession, tableDataPath);
     boolean deltaTableExists = deltaLog.tableExists();
     if (!deltaTableExists) {
@@ -110,6 +131,20 @@ public class DeltaClient implements TargetClient {
     this.deltaLog = deltaLog;
     this.tableName = tableName;
     this.logRetentionInHours = logRetentionInHours;
+  }
+
+  @Override
+  public void init(PerTableConfig perTableConfig, Configuration configuration) {
+    SparkSession sparkSession = DeltaClientUtils.buildSparkSession(configuration);
+
+    _init(
+        perTableConfig.getTableDataPath(),
+        perTableConfig.getTableName(),
+        perTableConfig.getTargetMetadataRetentionInHours(),
+        sparkSession,
+        DeltaSchemaExtractor.getInstance(),
+        DeltaPartitionExtractor.getInstance(),
+        DeltaDataFileUpdatesExtractor.builder().build());
   }
 
   @Override

--- a/core/src/main/java/io/onetable/hudi/ConfigurationBasedPartitionSpecExtractor.java
+++ b/core/src/main/java/io/onetable/hudi/ConfigurationBasedPartitionSpecExtractor.java
@@ -36,13 +36,13 @@ import io.onetable.schema.SchemaFieldFinder;
  */
 @AllArgsConstructor
 public class ConfigurationBasedPartitionSpecExtractor implements HudiSourcePartitionSpecExtractor {
-  private final HudiSourceConfig config;
+  private final HudiSourceConfigImpl config;
 
   @Override
   public List<OnePartitionField> spec(OneSchema tableSchema) {
     List<OnePartitionField> partitionFields =
         new ArrayList<>(config.getPartitionFieldSpecs().size());
-    for (HudiSourceConfig.PartitionFieldSpec fieldSpec : config.getPartitionFieldSpecs()) {
+    for (HudiSourceConfigImpl.PartitionFieldSpec fieldSpec : config.getPartitionFieldSpecs()) {
       OneField sourceField =
           SchemaFieldFinder.getInstance()
               .findFieldByPath(tableSchema, fieldSpec.getSourceFieldPath());

--- a/core/src/main/java/io/onetable/hudi/HudiSourceClientProvider.java
+++ b/core/src/main/java/io/onetable/hudi/HudiSourceClientProvider.java
@@ -45,7 +45,8 @@ public class HudiSourceClientProvider extends SourceClientProvider<HoodieInstant
     }
 
     final HudiSourcePartitionSpecExtractor sourcePartitionSpecExtractor =
-        sourceTableConfig.getHudiSourceConfig().loadSourcePartitionSpecExtractor();
+        (HudiSourcePartitionSpecExtractor)
+            sourceTableConfig.getHudiSourceConfig().loadSourcePartitionSpecExtractor();
 
     return new HudiClient(metaClient, sourcePartitionSpecExtractor);
   }

--- a/core/src/main/java/io/onetable/hudi/HudiSourceConfigImpl.java
+++ b/core/src/main/java/io/onetable/hudi/HudiSourceConfigImpl.java
@@ -28,17 +28,18 @@ import lombok.Value;
 
 import com.google.common.base.Preconditions;
 
+import io.onetable.client.HudiSourceConfig;
 import io.onetable.model.schema.PartitionTransformType;
 import io.onetable.reflection.ReflectionUtils;
 
 /** Configuration of Hudi source format for the sync process. */
 @Value
-public class HudiSourceConfig {
+public class HudiSourceConfigImpl implements HudiSourceConfig {
   String partitionSpecExtractorClass;
   List<PartitionFieldSpec> partitionFieldSpecs;
 
   @Builder
-  public HudiSourceConfig(String partitionSpecExtractorClass, String partitionFieldSpecConfig) {
+  public HudiSourceConfigImpl(String partitionSpecExtractorClass, String partitionFieldSpecConfig) {
     this.partitionSpecExtractorClass =
         partitionSpecExtractorClass == null
             ? ConfigurationBasedPartitionSpecExtractor.class.getName()
@@ -47,10 +48,18 @@ public class HudiSourceConfig {
   }
 
   @Value
-  public static class PartitionFieldSpec {
+  static class PartitionFieldSpec {
     String sourceFieldPath;
     PartitionTransformType transformType;
     String format;
+  }
+
+  public String getPartitionSpecExtractorClass() {
+    return partitionSpecExtractorClass;
+  }
+
+  public List<PartitionFieldSpec> getPartitionFieldSpecs() {
+    return partitionFieldSpecs;
   }
 
   private static List<PartitionFieldSpec> parsePartitionFieldSpecs(String input) {

--- a/core/src/main/java/io/onetable/hudi/HudiSourceConfigImpl.java
+++ b/core/src/main/java/io/onetable/hudi/HudiSourceConfigImpl.java
@@ -54,14 +54,6 @@ public class HudiSourceConfigImpl implements HudiSourceConfig {
     String format;
   }
 
-  public String getPartitionSpecExtractorClass() {
-    return partitionSpecExtractorClass;
-  }
-
-  public List<PartitionFieldSpec> getPartitionFieldSpecs() {
-    return partitionFieldSpecs;
-  }
-
   private static List<PartitionFieldSpec> parsePartitionFieldSpecs(String input) {
     if (input == null || input.isEmpty()) {
       return Collections.emptyList();

--- a/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
@@ -96,18 +96,20 @@ import io.onetable.spi.sync.TargetClient;
 
 @Log4j2
 public class HudiTargetClient implements TargetClient {
-  private final BaseFileUpdatesExtractor baseFileUpdatesExtractor;
-  private final AvroSchemaConverter avroSchemaConverter;
-  private final HudiTableManager hudiTableManager;
-  private final CommitStateCreator commitStateCreator;
-  private final int timelineRetentionInHours;
-  private final int maxNumDeltaCommitsBeforeCompaction;
-  private final String tableDataPath;
+  private BaseFileUpdatesExtractor baseFileUpdatesExtractor;
+  private AvroSchemaConverter avroSchemaConverter;
+  private HudiTableManager hudiTableManager;
+  private CommitStateCreator commitStateCreator;
+  private int timelineRetentionInHours;
+  private int maxNumDeltaCommitsBeforeCompaction;
+  private String tableDataPath;
   private Optional<HoodieTableMetaClient> metaClient;
   private CommitState commitState;
 
+  public HudiTargetClient() {}
+
   public HudiTargetClient(PerTableConfig perTableConfig, Configuration configuration) {
-    this(
+    _init(
         perTableConfig.getTableDataPath(),
         perTableConfig.getTargetMetadataRetentionInHours(),
         HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.defaultValue(),
@@ -145,6 +147,25 @@ public class HudiTargetClient implements TargetClient {
       AvroSchemaConverter avroSchemaConverter,
       HudiTableManager hudiTableManager,
       CommitStateCreator commitStateCreator) {
+
+    _init(
+        tableDataPath,
+        timelineRetentionInHours,
+        maxNumDeltaCommitsBeforeCompaction,
+        baseFileUpdatesExtractor,
+        avroSchemaConverter,
+        hudiTableManager,
+        commitStateCreator);
+  }
+
+  private void _init(
+      String tableDataPath,
+      int timelineRetentionInHours,
+      int maxNumDeltaCommitsBeforeCompaction,
+      BaseFileUpdatesExtractor baseFileUpdatesExtractor,
+      AvroSchemaConverter avroSchemaConverter,
+      HudiTableManager hudiTableManager,
+      CommitStateCreator commitStateCreator) {
     this.tableDataPath = tableDataPath;
     this.baseFileUpdatesExtractor = baseFileUpdatesExtractor;
     this.timelineRetentionInHours = timelineRetentionInHours;
@@ -154,6 +175,20 @@ public class HudiTargetClient implements TargetClient {
     // create meta client if table already exists
     this.metaClient = hudiTableManager.loadTableMetaClientIfExists(tableDataPath);
     this.commitStateCreator = commitStateCreator;
+  }
+
+  @Override
+  public void init(PerTableConfig perTableConfig, Configuration configuration) {
+    _init(
+        perTableConfig.getTableDataPath(),
+        perTableConfig.getTargetMetadataRetentionInHours(),
+        HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.defaultValue(),
+        BaseFileUpdatesExtractor.of(
+            new HoodieJavaEngineContext(configuration),
+            new CachingPath(perTableConfig.getTableDataPath())),
+        AvroSchemaConverter.getInstance(),
+        HudiTableManager.of(configuration),
+        CommitState::new);
   }
 
   @FunctionalInterface

--- a/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
+++ b/core/src/main/java/io/onetable/hudi/HudiTargetClient.java
@@ -108,19 +108,6 @@ public class HudiTargetClient implements TargetClient {
 
   public HudiTargetClient() {}
 
-  public HudiTargetClient(PerTableConfig perTableConfig, Configuration configuration) {
-    _init(
-        perTableConfig.getTableDataPath(),
-        perTableConfig.getTargetMetadataRetentionInHours(),
-        HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.defaultValue(),
-        BaseFileUpdatesExtractor.of(
-            new HoodieJavaEngineContext(configuration),
-            new CachingPath(perTableConfig.getTableDataPath())),
-        AvroSchemaConverter.getInstance(),
-        HudiTableManager.of(configuration),
-        CommitState::new);
-  }
-
   @VisibleForTesting
   HudiTargetClient(
       PerTableConfig perTableConfig,

--- a/core/src/main/java/io/onetable/iceberg/IcebergCatalogConfig.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergCatalogConfig.java
@@ -27,8 +27,20 @@ import lombok.Value;
 
 @Value
 @Builder
-public class IcebergCatalogConfig {
+public class IcebergCatalogConfig implements io.onetable.client.CatalogConfig {
   @NonNull String catalogImpl;
   @NonNull String catalogName;
   @NonNull @Builder.Default Map<String, String> catalogOptions = Collections.emptyMap();
+
+  public String getCatalogImpl() {
+    return catalogImpl;
+  }
+
+  public String getCatalogName() {
+    return catalogName;
+  }
+
+  public Map<String, String> getCatalogOptions() {
+    return catalogOptions;
+  }
 }

--- a/core/src/main/java/io/onetable/iceberg/IcebergCatalogConfig.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergCatalogConfig.java
@@ -31,16 +31,4 @@ public class IcebergCatalogConfig implements io.onetable.client.CatalogConfig {
   @NonNull String catalogImpl;
   @NonNull String catalogName;
   @NonNull @Builder.Default Map<String, String> catalogOptions = Collections.emptyMap();
-
-  public String getCatalogImpl() {
-    return catalogImpl;
-  }
-
-  public String getCatalogName() {
-    return catalogName;
-  }
-
-  public Map<String, String> getCatalogOptions() {
-    return catalogOptions;
-  }
 }

--- a/core/src/main/java/io/onetable/iceberg/IcebergClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergClient.java
@@ -56,20 +56,22 @@ import io.onetable.spi.sync.TargetClient;
 @Log4j2
 public class IcebergClient implements TargetClient {
   private static final String METADATA_DIR_PATH = "/metadata/";
-  private final IcebergSchemaExtractor schemaExtractor;
-  private final IcebergSchemaSync schemaSync;
-  private final IcebergPartitionSpecExtractor partitionSpecExtractor;
-  private final IcebergPartitionSpecSync partitionSpecSync;
-  private final IcebergDataFileUpdatesSync dataFileUpdatesExtractor;
-  private final IcebergTableManager tableManager;
-  private final String basePath;
-  private final TableIdentifier tableIdentifier;
-  private final IcebergCatalogConfig catalogConfig;
-  private final Configuration configuration;
-  private final int snapshotRetentionInHours;
+  private IcebergSchemaExtractor schemaExtractor;
+  private IcebergSchemaSync schemaSync;
+  private IcebergPartitionSpecExtractor partitionSpecExtractor;
+  private IcebergPartitionSpecSync partitionSpecSync;
+  private IcebergDataFileUpdatesSync dataFileUpdatesExtractor;
+  private IcebergTableManager tableManager;
+  private String basePath;
+  private TableIdentifier tableIdentifier;
+  private IcebergCatalogConfig catalogConfig;
+  private Configuration configuration;
+  private int snapshotRetentionInHours;
   private Transaction transaction;
   private Table table;
   private OneTable internalTableState;
+
+  public IcebergClient() {}
 
   public IcebergClient(PerTableConfig perTableConfig, Configuration configuration) {
     this(
@@ -94,6 +96,26 @@ public class IcebergClient implements TargetClient {
       IcebergPartitionSpecSync partitionSpecSync,
       IcebergDataFileUpdatesSync dataFileUpdatesExtractor,
       IcebergTableManager tableManager) {
+    _init(
+        perTableConfig,
+        configuration,
+        schemaExtractor,
+        schemaSync,
+        partitionSpecExtractor,
+        partitionSpecSync,
+        dataFileUpdatesExtractor,
+        tableManager);
+  }
+
+  private void _init(
+      PerTableConfig perTableConfig,
+      Configuration configuration,
+      IcebergSchemaExtractor schemaExtractor,
+      IcebergSchemaSync schemaSync,
+      IcebergPartitionSpecExtractor partitionSpecExtractor,
+      IcebergPartitionSpecSync partitionSpecSync,
+      IcebergDataFileUpdatesSync dataFileUpdatesExtractor,
+      IcebergTableManager tableManager) {
     this.schemaExtractor = schemaExtractor;
     this.schemaSync = schemaSync;
     this.partitionSpecExtractor = partitionSpecExtractor;
@@ -109,7 +131,7 @@ public class IcebergClient implements TargetClient {
             ? TableIdentifier.of(tableName)
             : TableIdentifier.of(Namespace.of(namespace), tableName);
     this.tableManager = tableManager;
-    this.catalogConfig = perTableConfig.getIcebergCatalogConfig();
+    this.catalogConfig = (IcebergCatalogConfig) perTableConfig.getIcebergCatalogConfig();
 
     if (tableManager.tableExists(catalogConfig, tableIdentifier, basePath)) {
       // Load the table state if it already exists
@@ -117,6 +139,21 @@ public class IcebergClient implements TargetClient {
     }
     // Clear any corrupted state before using the target client
     rollbackCorruptCommits();
+  }
+
+  @Override
+  public void init(PerTableConfig perTableConfig, Configuration configuration) {
+    _init(
+        perTableConfig,
+        configuration,
+        IcebergSchemaExtractor.getInstance(),
+        IcebergSchemaSync.getInstance(),
+        IcebergPartitionSpecExtractor.getInstance(),
+        IcebergPartitionSpecSync.getInstance(),
+        IcebergDataFileUpdatesSync.of(
+            IcebergColumnStatsConverter.getInstance(),
+            IcebergPartitionValueConverter.getInstance()),
+        IcebergTableManager.of(configuration));
   }
 
   @Override

--- a/core/src/main/java/io/onetable/iceberg/IcebergClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergClient.java
@@ -73,20 +73,6 @@ public class IcebergClient implements TargetClient {
 
   public IcebergClient() {}
 
-  public IcebergClient(PerTableConfig perTableConfig, Configuration configuration) {
-    this(
-        perTableConfig,
-        configuration,
-        IcebergSchemaExtractor.getInstance(),
-        IcebergSchemaSync.getInstance(),
-        IcebergPartitionSpecExtractor.getInstance(),
-        IcebergPartitionSpecSync.getInstance(),
-        IcebergDataFileUpdatesSync.of(
-            IcebergColumnStatsConverter.getInstance(),
-            IcebergPartitionValueConverter.getInstance()),
-        IcebergTableManager.of(configuration));
-  }
-
   IcebergClient(
       PerTableConfig perTableConfig,
       Configuration configuration,

--- a/core/src/main/java/io/onetable/iceberg/IcebergSourceClient.java
+++ b/core/src/main/java/io/onetable/iceberg/IcebergSourceClient.java
@@ -80,7 +80,7 @@ public class IcebergSourceClient implements SourceClient<Snapshot> {
             ? TableIdentifier.of(tableName)
             : TableIdentifier.of(Namespace.of(namespace), tableName);
     return tableManager.getTable(
-        sourceTableConfig.getIcebergCatalogConfig(),
+        (IcebergCatalogConfig) sourceTableConfig.getIcebergCatalogConfig(),
         tableIdentifier,
         sourceTableConfig.getTableBasePath());
   }

--- a/core/src/main/resources/META-INF/services/io.onetable.spi.sync.TargetClient
+++ b/core/src/main/resources/META-INF/services/io.onetable.spi.sync.TargetClient
@@ -1,0 +1,21 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+io.onetable.hudi.HudiTargetClient
+io.onetable.delta.DeltaClient
+io.onetable.iceberg.IcebergClient

--- a/core/src/test/java/io/onetable/ITOneTableClient.java
+++ b/core/src/test/java/io/onetable/ITOneTableClient.java
@@ -83,10 +83,11 @@ import com.google.common.collect.ImmutableList;
 
 import io.onetable.client.OneTableClient;
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.client.SourceClientProvider;
 import io.onetable.delta.DeltaSourceClientProvider;
 import io.onetable.hudi.HudiSourceClientProvider;
-import io.onetable.hudi.HudiSourceConfig;
+import io.onetable.hudi.HudiSourceConfigImpl;
 import io.onetable.hudi.HudiTestUtil;
 import io.onetable.iceberg.IcebergSourceClientProvider;
 import io.onetable.model.storage.TableFormat;
@@ -190,13 +191,13 @@ public class ITOneTableClient {
       insertRecords = table.insertRows(100);
 
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(targetTableFormats)
               .tableBasePath(table.getBasePath())
               .tableDataPath(table.getDataPath())
               .hudiSourceConfig(
-                  HudiSourceConfig.builder()
+                  HudiSourceConfigImpl.builder()
                       .partitionFieldSpecConfig(oneTablePartitionConfig)
                       .build())
               .syncMode(syncMode)
@@ -221,13 +222,13 @@ public class ITOneTableClient {
         GenericTable.getInstanceWithAdditionalColumns(
             tableName, tempDir, sparkSession, jsc, sourceTableFormat, isPartitioned)) {
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(targetTableFormats)
               .tableBasePath(tableWithUpdatedSchema.getBasePath())
               .tableDataPath(tableWithUpdatedSchema.getDataPath())
               .hudiSourceConfig(
-                  HudiSourceConfig.builder()
+                  HudiSourceConfigImpl.builder()
                       .partitionFieldSpecConfig(oneTablePartitionConfig)
                       .build())
               .syncMode(syncMode)
@@ -280,12 +281,12 @@ public class ITOneTableClient {
       table.insertRecordsWithCommitAlreadyStarted(insertsForCommit2, commitInstant2, true);
 
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(targetTableFormats)
               .tableBasePath(table.getBasePath())
               .hudiSourceConfig(
-                  HudiSourceConfig.builder()
+                  HudiSourceConfigImpl.builder()
                       .partitionFieldSpecConfig(partitionConfig.getOneTableConfig())
                       .build())
               .syncMode(syncMode)
@@ -314,12 +315,12 @@ public class ITOneTableClient {
       List<HoodieRecord<HoodieAvroPayload>> insertedRecords1 = table.insertRecords(50, true);
 
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(targetTableFormats)
               .tableBasePath(table.getBasePath())
               .hudiSourceConfig(
-                  HudiSourceConfig.builder()
+                  HudiSourceConfigImpl.builder()
                       .partitionFieldSpecConfig(partitionConfig.getOneTableConfig())
                       .build())
               .syncMode(syncMode)
@@ -361,7 +362,7 @@ public class ITOneTableClient {
       table.insertRows(50);
       List<String> targetTableFormats = getOtherFormats(sourceTableFormat);
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(targetTableFormats)
               .tableBasePath(table.getBasePath())
@@ -481,13 +482,13 @@ public class ITOneTableClient {
     }
     try (GenericTable tableToClose = table) {
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(targetTableFormats)
               .tableBasePath(tableToClose.getBasePath())
               .tableDataPath(tableToClose.getDataPath())
               .hudiSourceConfig(
-                  HudiSourceConfig.builder()
+                  HudiSourceConfigImpl.builder()
                       .partitionFieldSpecConfig(oneTablePartitionConfig)
                       .build())
               .syncMode(SyncMode.INCREMENTAL)
@@ -515,7 +516,7 @@ public class ITOneTableClient {
       table.insertRecords(100, true);
 
       PerTableConfig perTableConfigIceberg =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(ImmutableList.of(ICEBERG))
               .tableBasePath(table.getBasePath())
@@ -523,7 +524,7 @@ public class ITOneTableClient {
               .build();
 
       PerTableConfig perTableConfigDelta =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(ImmutableList.of(DELTA))
               .tableBasePath(table.getBasePath())
@@ -552,7 +553,7 @@ public class ITOneTableClient {
         TestJavaHudiTable.forStandardSchema(
             tableName, tempDir, null, HoodieTableType.COPY_ON_WRITE)) {
       PerTableConfig singleTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(ImmutableList.of(ICEBERG))
               .tableBasePath(table.getBasePath())
@@ -560,7 +561,7 @@ public class ITOneTableClient {
               .build();
 
       PerTableConfig dualTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(Arrays.asList(ICEBERG, DELTA))
               .tableBasePath(table.getBasePath())
@@ -604,7 +605,7 @@ public class ITOneTableClient {
       table.insertRows(20);
       OneTableClient oneTableClient = new OneTableClient(jsc.hadoopConfiguration());
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(Collections.singletonList(ICEBERG))
               .tableBasePath(table.getBasePath())
@@ -637,7 +638,7 @@ public class ITOneTableClient {
         TestJavaHudiTable.forStandardSchema(
             tableName, tempDir, null, HoodieTableType.COPY_ON_WRITE)) {
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(Arrays.asList(ICEBERG, DELTA))
               .tableBasePath(table.getBasePath())

--- a/core/src/test/java/io/onetable/client/TestOneTableClient.java
+++ b/core/src/test/java/io/onetable/client/TestOneTableClient.java
@@ -394,7 +394,7 @@ public class TestOneTableClient {
   }
 
   private PerTableConfig getPerTableConfig(List<String> targetTableFormats, SyncMode syncMode) {
-    return PerTableConfig.builder()
+    return PerTableConfigImpl.builder()
         .tableName(getTableName())
         .tableBasePath("/tmp/doesnt/matter")
         .targetTableFormats(targetTableFormats)

--- a/core/src/test/java/io/onetable/client/TestPerTableConfig.java
+++ b/core/src/test/java/io/onetable/client/TestPerTableConfig.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import io.onetable.hudi.HudiSourceConfig;
+import io.onetable.hudi.HudiSourceConfigImpl;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
 
@@ -35,7 +35,7 @@ class TestPerTableConfig {
   @Test
   void sanitizePath() {
     PerTableConfig tooManySlashes =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableBasePath("s3://bucket//path")
             .tableName("name")
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -43,7 +43,7 @@ class TestPerTableConfig {
     assertEquals("s3://bucket/path", tooManySlashes.getTableBasePath());
 
     PerTableConfig localFilePath =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableBasePath("/local/data//path")
             .tableName("name")
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -51,7 +51,7 @@ class TestPerTableConfig {
     assertEquals("file:///local/data/path", localFilePath.getTableBasePath());
 
     PerTableConfig properLocalFilePath =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableBasePath("file:///local/data//path")
             .tableName("name")
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -62,7 +62,7 @@ class TestPerTableConfig {
   @Test
   void defaultValueSet() {
     PerTableConfig perTableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableBasePath("file://bucket/path")
             .tableName("name")
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -70,7 +70,7 @@ class TestPerTableConfig {
 
     assertEquals(24 * 7, perTableConfig.getTargetMetadataRetentionInHours());
     assertEquals(SyncMode.INCREMENTAL, perTableConfig.getSyncMode());
-    assertEquals(HudiSourceConfig.builder().build(), perTableConfig.getHudiSourceConfig());
+    assertEquals(HudiSourceConfigImpl.builder().build(), perTableConfig.getHudiSourceConfig());
     assertNull(perTableConfig.getNamespace());
     assertNull(perTableConfig.getIcebergCatalogConfig());
   }
@@ -80,7 +80,7 @@ class TestPerTableConfig {
     assertThrows(
         NullPointerException.class,
         () ->
-            PerTableConfig.builder()
+            PerTableConfigImpl.builder()
                 .tableName("name")
                 .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
                 .build());
@@ -88,7 +88,7 @@ class TestPerTableConfig {
     assertThrows(
         NullPointerException.class,
         () ->
-            PerTableConfig.builder()
+            PerTableConfigImpl.builder()
                 .tableBasePath("file://bucket/path")
                 .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
                 .build());
@@ -96,7 +96,10 @@ class TestPerTableConfig {
     assertThrows(
         NullPointerException.class,
         () ->
-            PerTableConfig.builder().tableBasePath("file://bucket/path").tableName("name").build());
+            PerTableConfigImpl.builder()
+                .tableBasePath("file://bucket/path")
+                .tableName("name")
+                .build());
   }
 
   @Test
@@ -105,7 +108,7 @@ class TestPerTableConfig {
         assertThrows(
             IllegalArgumentException.class,
             () ->
-                PerTableConfig.builder()
+                PerTableConfigImpl.builder()
                     .tableName("name")
                     .tableBasePath("file://bucket/path")
                     .targetTableFormats(Collections.emptyList())

--- a/core/src/test/java/io/onetable/client/TestTableFormatClientFactory.java
+++ b/core/src/test/java/io/onetable/client/TestTableFormatClientFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package io.onetable.client;
+
+import static io.onetable.GenericTable.getTableName;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import io.onetable.exception.NotSupportedException;
+import io.onetable.model.storage.TableFormat;
+import io.onetable.model.sync.SyncMode;
+import io.onetable.spi.sync.TargetClient;
+
+public class TestTableFormatClientFactory {
+
+  @Test
+  public void testTableClientFromNameForDELTA() {
+    TargetClient tc =
+        TableFormatClientFactory.getInstance().createTargetClientForName(TableFormat.DELTA);
+    assertNotNull(tc);
+    PerTableConfig perTableConfig =
+        getPerTableConfig(Arrays.asList(TableFormat.DELTA), SyncMode.INCREMENTAL);
+    Configuration conf = new Configuration();
+    conf.setStrings("spark.master", "local");
+    tc.init(perTableConfig, conf);
+    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.DELTA));
+  }
+
+  @Test
+  public void testTableClientFromNameForHUDI() {
+    TargetClient tc =
+        TableFormatClientFactory.getInstance().createTargetClientForName(TableFormat.HUDI);
+    assertNotNull(tc);
+    PerTableConfig perTableConfig =
+        getPerTableConfig(Arrays.asList(TableFormat.HUDI), SyncMode.INCREMENTAL);
+    Configuration conf = new Configuration();
+    conf.setStrings("spark.master", "local");
+    tc.init(perTableConfig, conf);
+    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.HUDI));
+  }
+
+  @Test
+  public void testTableClientFromNameForICEBERG() {
+    TargetClient tc =
+        TableFormatClientFactory.getInstance().createTargetClientForName(TableFormat.ICEBERG);
+    assertNotNull(tc);
+    PerTableConfig perTableConfig =
+        getPerTableConfig(Arrays.asList(TableFormat.ICEBERG), SyncMode.INCREMENTAL);
+    Configuration conf = new Configuration();
+    conf.setStrings("spark.master", "local");
+    tc.init(perTableConfig, conf);
+    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.ICEBERG));
+  }
+
+  @Test
+  public void testTableClientFromNameForUNKOWN() {
+    try {
+      TargetClient tc = TableFormatClientFactory.getInstance().createTargetClientForName("UNKOWN");
+      fail("NotSupportedException expected and operation succeeded inappropriately.");
+    } catch (NotSupportedException e) {
+      // this is expected
+    }
+  }
+
+  @Test
+  public void testTableClientFromFormatType() {
+    PerTableConfig perTableConfig =
+        getPerTableConfig(Arrays.asList(TableFormat.DELTA), SyncMode.INCREMENTAL);
+    Configuration conf = new Configuration();
+    conf.setStrings("spark.master", "local");
+    TargetClient tc =
+        TableFormatClientFactory.getInstance()
+            .createForFormat(TableFormat.DELTA, perTableConfig, conf);
+    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.DELTA));
+  }
+
+  private PerTableConfig getPerTableConfig(List<String> targetTableFormats, SyncMode syncMode) {
+    return PerTableConfigImpl.builder()
+        .tableName(getTableName())
+        .tableBasePath("/tmp/doesnt/matter")
+        .targetTableFormats(targetTableFormats)
+        .syncMode(syncMode)
+        .build();
+  }
+}

--- a/core/src/test/java/io/onetable/client/TestTableFormatClientFactory.java
+++ b/core/src/test/java/io/onetable/client/TestTableFormatClientFactory.java
@@ -19,8 +19,10 @@
 package io.onetable.client;
 
 import static io.onetable.GenericTable.getTableName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,7 +47,7 @@ public class TestTableFormatClientFactory {
     Configuration conf = new Configuration();
     conf.setStrings("spark.master", "local");
     tc.init(perTableConfig, conf);
-    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.DELTA));
+    assertEquals(tc.getTableFormat(), TableFormat.DELTA);
   }
 
   @Test
@@ -58,7 +60,7 @@ public class TestTableFormatClientFactory {
     Configuration conf = new Configuration();
     conf.setStrings("spark.master", "local");
     tc.init(perTableConfig, conf);
-    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.HUDI));
+    assertEquals(tc.getTableFormat(), TableFormat.HUDI);
   }
 
   @Test
@@ -71,17 +73,17 @@ public class TestTableFormatClientFactory {
     Configuration conf = new Configuration();
     conf.setStrings("spark.master", "local");
     tc.init(perTableConfig, conf);
-    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.ICEBERG));
+    assertEquals(tc.getTableFormat(), TableFormat.ICEBERG);
   }
 
   @Test
   public void testTableClientFromNameForUNKOWN() {
-    try {
-      TargetClient tc = TableFormatClientFactory.getInstance().createTargetClientForName("UNKOWN");
-      fail("NotSupportedException expected and operation succeeded inappropriately.");
-    } catch (NotSupportedException e) {
-      // this is expected
-    }
+    NotSupportedException thrown =
+        assertThrows(
+            NotSupportedException.class,
+            () -> TableFormatClientFactory.getInstance().createTargetClientForName("UNKNOWN"),
+            "NotSupportedException expected and operation succeeded inappropriately.");
+    assertTrue(thrown.getMessage().contains("UNKNOWN"));
   }
 
   @Test
@@ -93,7 +95,7 @@ public class TestTableFormatClientFactory {
     TargetClient tc =
         TableFormatClientFactory.getInstance()
             .createForFormat(TableFormat.DELTA, perTableConfig, conf);
-    assertNotNull(tc.getTableFormat().equalsIgnoreCase(TableFormat.DELTA));
+    assertEquals(tc.getTableFormat(), TableFormat.DELTA);
   }
 
   private PerTableConfig getPerTableConfig(List<String> targetTableFormats, SyncMode syncMode) {

--- a/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
+++ b/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.onetable.TestSparkDeltaTable;
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.model.*;
 import io.onetable.model.CommitsBacklog;
 import io.onetable.model.schema.OneField;
@@ -160,7 +161,7 @@ public class ITDeltaSourceClient {
             + "' AS SELECT * FROM VALUES (1, 2)");
     // Create Delta source client
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(tableName)
             .tableBasePath(basePath.toString())
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -218,7 +219,7 @@ public class ITDeltaSourceClient {
             + "' AS SELECT 'SingleValue' AS part_col, 1 AS col1, 2 AS col2");
     // Create Delta source client
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(tableName)
             .tableBasePath(basePath.toString())
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -306,7 +307,7 @@ public class ITDeltaSourceClient {
             + "` VALUES(1, CAST('2012-02-12 00:12:34' AS TIMESTAMP))");
     // Create Delta source client
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(tableName)
             .tableBasePath(basePath.toString())
             .targetTableFormats(Collections.singletonList(TableFormat.ICEBERG))
@@ -345,7 +346,7 @@ public class ITDeltaSourceClient {
     testSparkDeltaTable.insertRows(50);
     allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(testSparkDeltaTable.getTableName())
             .tableBasePath(testSparkDeltaTable.getBasePath())
             .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.ICEBERG))
@@ -383,7 +384,7 @@ public class ITDeltaSourceClient {
     List<Row> commit1Rows = testSparkDeltaTable.insertRowsForPartition(50, 2018);
     Long timestamp1 = testSparkDeltaTable.getLastCommitTimestamp();
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(testSparkDeltaTable.getTableName())
             .tableBasePath(testSparkDeltaTable.getBasePath())
             .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.ICEBERG))
@@ -450,7 +451,7 @@ public class ITDeltaSourceClient {
     allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
 
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(testSparkDeltaTable.getTableName())
             .tableBasePath(testSparkDeltaTable.getBasePath())
             .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.ICEBERG))
@@ -496,7 +497,7 @@ public class ITDeltaSourceClient {
     allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
 
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(testSparkDeltaTable.getTableName())
             .tableBasePath(testSparkDeltaTable.getBasePath())
             .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.ICEBERG))
@@ -551,7 +552,7 @@ public class ITDeltaSourceClient {
     allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
 
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(testSparkDeltaTable.getTableName())
             .tableBasePath(testSparkDeltaTable.getBasePath())
             .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.ICEBERG))
@@ -609,7 +610,7 @@ public class ITDeltaSourceClient {
     allActiveFiles.add(testSparkDeltaTable.getAllActiveFiles());
 
     PerTableConfig tableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(testSparkDeltaTable.getTableName())
             .tableBasePath(testSparkDeltaTable.getBasePath())
             .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.ICEBERG))

--- a/core/src/test/java/io/onetable/delta/TestDeltaSync.java
+++ b/core/src/test/java/io/onetable/delta/TestDeltaSync.java
@@ -76,7 +76,7 @@ import io.delta.standalone.expressions.Literal;
 import io.delta.standalone.types.IntegerType;
 import io.delta.standalone.types.StringType;
 
-import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
 import io.onetable.model.schema.OneField;
@@ -126,7 +126,7 @@ public class TestDeltaSync {
     Files.createDirectories(basePath);
     deltaClient =
         new DeltaClient(
-            PerTableConfig.builder()
+            PerTableConfigImpl.builder()
                 .tableName(tableName)
                 .tableBasePath(basePath.toString())
                 .targetMetadataRetentionInHours(1)

--- a/core/src/test/java/io/onetable/hudi/ITHudiSourceClient.java
+++ b/core/src/test/java/io/onetable/hudi/ITHudiSourceClient.java
@@ -534,7 +534,9 @@ public class ITHudiSourceClient {
             .build();
     HudiSourcePartitionSpecExtractor partitionSpecExtractor =
         new ConfigurationBasedPartitionSpecExtractor(
-            HudiSourceConfig.builder().partitionFieldSpecConfig(onetablePartitionConfig).build());
+            HudiSourceConfigImpl.builder()
+                .partitionFieldSpecConfig(onetablePartitionConfig)
+                .build());
     return new HudiClient(hoodieTableMetaClient, partitionSpecExtractor);
   }
 

--- a/core/src/test/java/io/onetable/hudi/ITHudiTargetClient.java
+++ b/core/src/test/java/io/onetable/hudi/ITHudiTargetClient.java
@@ -70,7 +70,7 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataFileSystemView;
 
-import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.model.OneTable;
 import io.onetable.model.OneTableMetadata;
 import io.onetable.model.schema.OneField;
@@ -581,7 +581,7 @@ public class ITHudiTargetClient {
 
   private HudiTargetClient getTargetClient() {
     return new HudiTargetClient(
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableBasePath(tableBasePath)
             .targetTableFormats(Collections.singletonList(TableFormat.HUDI))
             .tableName("test_table")

--- a/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/ITIcebergSourceClient.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.data.Record;
 
 import io.onetable.TestIcebergTable;
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.model.CommitsBacklog;
 import io.onetable.model.InstantsForIncrementalSync;
 import io.onetable.model.OneSnapshot;
@@ -95,7 +96,7 @@ public class ITIcebergSourceClient {
       allActiveFiles.add(testIcebergTable.getAllActiveFiles());
 
       PerTableConfig tableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(testIcebergTable.getTableName())
               .tableBasePath(testIcebergTable.getBasePath())
               .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.DELTA))
@@ -154,7 +155,7 @@ public class ITIcebergSourceClient {
       allActiveFiles.add(testIcebergTable.getAllActiveFiles());
 
       PerTableConfig tableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(testIcebergTable.getTableName())
               .tableBasePath(testIcebergTable.getBasePath())
               .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.DELTA))
@@ -213,7 +214,7 @@ public class ITIcebergSourceClient {
       allActiveFiles.add(testIcebergTable.getAllActiveFiles());
 
       PerTableConfig tableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(testIcebergTable.getTableName())
               .tableBasePath(testIcebergTable.getBasePath())
               .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.DELTA))
@@ -272,7 +273,7 @@ public class ITIcebergSourceClient {
       allActiveFiles.add(testIcebergTable.getAllActiveFiles());
 
       PerTableConfig tableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(testIcebergTable.getTableName())
               .tableBasePath(testIcebergTable.getBasePath())
               .targetTableFormats(Arrays.asList(TableFormat.HUDI, TableFormat.DELTA))
@@ -312,7 +313,7 @@ public class ITIcebergSourceClient {
       List<Record> commit1Rows = testIcebergTable.insertRecordsForPartition(50, "INFO");
       Long timestamp1 = testIcebergTable.getLastCommitTimestamp();
       PerTableConfig tableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(testIcebergTable.getTableName())
               .tableBasePath(testIcebergTable.getBasePath())
               .tableDataPath(testIcebergTable.getDataPath())

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.types.Types;
 
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.model.*;
 import io.onetable.model.schema.*;
 import io.onetable.model.stat.PartitionValue;
@@ -407,7 +408,7 @@ class TestIcebergSourceClient {
   }
 
   private static PerTableConfig getPerTableConfig(Table catalogSales) {
-    return PerTableConfig.builder()
+    return PerTableConfigImpl.builder()
         .tableName(catalogSales.name())
         .tableBasePath(catalogSales.location())
         .targetTableFormats(Collections.singletonList(TableFormat.DELTA))

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSync.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSync.java
@@ -82,7 +82,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import io.onetable.ITOneTableClient;
-import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.model.OneSnapshot;
 import io.onetable.model.OneTable;
 import io.onetable.model.OneTableMetadata;
@@ -187,7 +187,7 @@ public class TestIcebergSync {
 
   private IcebergClient getIcebergClient() {
     return new IcebergClient(
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableBasePath(basePath.toString())
             .tableName(tableName)
             .targetMetadataRetentionInHours(1)

--- a/core/src/test/java/io/onetable/loadtest/LoadTest.java
+++ b/core/src/test/java/io/onetable/loadtest/LoadTest.java
@@ -37,6 +37,7 @@ import org.apache.hudi.config.HoodieArchivalConfig;
 import io.onetable.TestJavaHudiTable;
 import io.onetable.client.OneTableClient;
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.client.SourceClientProvider;
 import io.onetable.hudi.HudiSourceClientProvider;
 import io.onetable.model.storage.TableFormat;
@@ -75,7 +76,7 @@ public class LoadTest {
             false);
       }
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(Arrays.asList(TableFormat.ICEBERG, TableFormat.DELTA))
               .tableBasePath(table.getBasePath())
@@ -104,7 +105,7 @@ public class LoadTest {
             tableName, tempDir, "level:SIMPLE", HoodieTableType.COPY_ON_WRITE, archivalConfig)) {
       table.insertRecords(1, "partition0", false);
       PerTableConfig perTableConfig =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableName(tableName)
               .targetTableFormats(Arrays.asList(TableFormat.ICEBERG, TableFormat.DELTA))
               .tableBasePath(table.getBasePath())

--- a/hudi-support/extensions/src/main/java/io/onetable/hudi/sync/OneTableSyncTool.java
+++ b/hudi-support/extensions/src/main/java/io/onetable/hudi/sync/OneTableSyncTool.java
@@ -36,8 +36,9 @@ import org.apache.hudi.sync.common.HoodieSyncTool;
 
 import io.onetable.client.OneTableClient;
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.hudi.HudiSourceClientProvider;
-import io.onetable.hudi.HudiSourceConfig;
+import io.onetable.hudi.HudiSourceConfigImpl;
 import io.onetable.model.schema.PartitionTransformType;
 import io.onetable.model.sync.SyncMode;
 import io.onetable.model.sync.SyncResult;
@@ -63,12 +64,12 @@ public class OneTableSyncTool extends HoodieSyncTool {
     String basePath = config.getString(HoodieSyncConfig.META_SYNC_BASE_PATH);
     String tableName = config.getString(HoodieTableConfig.HOODIE_TABLE_NAME_KEY);
     PerTableConfig perTableConfig =
-        PerTableConfig.builder()
+        PerTableConfigImpl.builder()
             .tableName(tableName)
             .tableBasePath(basePath)
             .targetTableFormats(formatsToSync)
             .hudiSourceConfig(
-                HudiSourceConfig.builder()
+                HudiSourceConfigImpl.builder()
                     .partitionFieldSpecConfig(getPartitionSpecConfig())
                     .build())
             .syncMode(SyncMode.INCREMENTAL)

--- a/utilities/src/main/java/io/onetable/utilities/RunSync.java
+++ b/utilities/src/main/java/io/onetable/utilities/RunSync.java
@@ -46,9 +46,10 @@ import com.google.common.annotations.VisibleForTesting;
 
 import io.onetable.client.OneTableClient;
 import io.onetable.client.PerTableConfig;
+import io.onetable.client.PerTableConfigImpl;
 import io.onetable.client.SourceClientProvider;
 import io.onetable.hudi.ConfigurationBasedPartitionSpecExtractor;
-import io.onetable.hudi.HudiSourceConfig;
+import io.onetable.hudi.HudiSourceConfigImpl;
 import io.onetable.iceberg.IcebergCatalogConfig;
 import io.onetable.model.storage.TableFormat;
 import io.onetable.model.sync.SyncMode;
@@ -148,14 +149,14 @@ public class RunSync {
           table.getTableBasePath(),
           tableFormatList);
       PerTableConfig config =
-          PerTableConfig.builder()
+          PerTableConfigImpl.builder()
               .tableBasePath(table.getTableBasePath())
               .tableName(table.getTableName())
               .namespace(table.getNamespace() == null ? null : table.getNamespace().split("\\."))
               .tableDataPath(table.getTableDataPath())
               .icebergCatalogConfig(icebergCatalogConfig)
               .hudiSourceConfig(
-                  HudiSourceConfig.builder()
+                  HudiSourceConfigImpl.builder()
                       .partitionSpecExtractorClass(
                           ConfigurationBasedPartitionSpecExtractor.class.getName())
                       .partitionFieldSpecConfig(table.getPartitionSpec())


### PR DESCRIPTION
#304 represents the intent of this PR towards the larger extensibility improvements.

## What is the purpose of the pull request

This change will introduce the use of ServiceLoader by the TableFormatClientFactory to discover the TargetClient implementations by TableFormat which was recently changed from an Enum to a String in preparation for this change.

ServiceLoader will load all implementations on the classpath (built-in to OneTable or added by the user) and select the intended client implementation by name provided for the Sync via argument or configuration.

This will allow users and/or tooling vendors to extend the capabilities without requiring all TargetClient's to be committed to the project.

## Brief change log

* Refactored TableFormatClientFactory to use ServiceLoader
* Refactored existing clients to have a default no-arg ctor and an init() for initializing the client with required config
* Removed final qualifiers from members so that init() can set them after construction
* Extracted interfaces from PerTableConfig, HudiSourceConfig, IcebergCatalogConfig in order to maintain the decoupling of the api and core modules after needing the config files in the init()
* Moved to the use of the PerTableConfig interface wherever possible

## Verify this pull request

This pull request is already covered by many existing tests.
Also added a new test in TestTableFormatClientFactory for the factory use in general but also specifically for the use of ServiceLoader.

