### PR TITLE
Upgrade Iceberg version

### DIFF
--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
@@ -250,6 +250,7 @@ class TestIcebergSourceClient {
       catalogSales
           .newRewrite()
           .addFile(newFile)
+          .validateFromSnapshot(snapshot2.snapshotId()) // since snapshot1 was expired, validation should exclude it
           .deleteFile(dataFiles.get(0))
           .deleteFile(dataFiles.get(1))
           .commit();

--- a/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
+++ b/core/src/test/java/io/onetable/iceberg/TestIcebergSourceClient.java
@@ -250,7 +250,8 @@ class TestIcebergSourceClient {
       catalogSales
           .newRewrite()
           .addFile(newFile)
-          .validateFromSnapshot(snapshot2.snapshotId()) // since snapshot1 was expired, validation should exclude it
+          .validateFromSnapshot(snapshot2.snapshotId())
+          // rewrite operation requires validation to snapshot1 as it was expired earlier
           .deleteFile(dataFiles.get(0))
           .deleteFile(dataFiles.get(1))
           .commit();

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <scala.version.prefix>2.12</scala.version.prefix>
         <spark.version>3.2.1</spark.version>
         <spark.version.prefix>3.2</spark.version.prefix>
-        <iceberg.version>1.3.1</iceberg.version>
+        <iceberg.version>1.4.2</iceberg.version>
         <delta.version>2.0.2</delta.version>
         <jackson.version>2.14.2</jackson.version>
         <test.plugin.version>2.22.2</test.plugin.version>


### PR DESCRIPTION
Fixes #309 

Upgrade Iceberg version from 1.3 to 1.4

New version will enable direct FileIO for public clouds. This feature allows OneTable to read and write data directly from cloud storage without using Hadoop FileSystem API, which improves performance and reduces overhead.
For example see: [ADLSFileIO](https://github.com/apache/iceberg/pull/8303/files)

This pull request is a trivial without any test coverage.