### PR TITLE
Upgrade hadoop-aws version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-aws</artifactId>
-                <version>3.2.2</version>
+                <version>3.3.1</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## *Important Read*

Issue #308 

## What is the purpose of the pull request

Fix an access denied issue on copying a file in S3.

## Brief change log

Bumped the `hadoop-aws` version from `3.2.2` to `3.3.1`

## Verify this pull request

This pull request is a library version change. Project builds correctly and migration from Delta to Iceberg works using S3.

