### PR TITLE
Optimize object creation for new Delta snapshot

### DIFF
--- a/core/src/main/java/io/onetable/delta/DeltaDataFileExtractor.java
+++ b/core/src/main/java/io/onetable/delta/DeltaDataFileExtractor.java
@@ -46,17 +46,6 @@ public class DeltaDataFileExtractor {
   private final DeltaActionsConverter actionsConverter = DeltaActionsConverter.getInstance();
 
   /**
-   * Initializes an iterator for Delta Lake files. This should only be used when column stats are
-   * not required.
-   *
-   * @return Delta table file iterator, files returned do not have column stats set to reduce memory
-   *     overhead
-   */
-  public DataFileIterator iteratorWithoutStats(Snapshot deltaSnapshot, OneSchema schema) {
-    return new DeltaDataFileIterator(deltaSnapshot, schema, false);
-  }
-
-  /**
    * Initializes an iterator for Delta Lake files.
    *
    * @return Delta table file iterator
@@ -70,8 +59,6 @@ public class DeltaDataFileExtractor {
     private final List<OneField> fields;
     private final List<OnePartitionField> partitionFields;
     private final Iterator<OneDataFile> dataFilesIterator;
-    private final String tableBasePath;
-    private final boolean includeColumnStats;
 
     private DeltaDataFileIterator(Snapshot snapshot, OneSchema schema, boolean includeColumnStats) {
       this.fileFormat =
@@ -80,8 +67,6 @@ public class DeltaDataFileExtractor {
       this.partitionFields =
           partitionExtractor.convertFromDeltaPartitionFormat(
               schema, snapshot.metadata().partitionSchema());
-      this.tableBasePath = snapshot.deltaLog().dataPath().toUri().toString();
-      this.includeColumnStats = includeColumnStats;
       this.dataFilesIterator =
           snapshot.allFiles().collectAsList().stream()
               .map(

--- a/core/src/main/java/io/onetable/delta/DeltaDataFileUpdatesExtractor.java
+++ b/core/src/main/java/io/onetable/delta/DeltaDataFileUpdatesExtractor.java
@@ -21,8 +21,7 @@ package io.onetable.delta;
 import static io.onetable.collectors.CustomCollectors.toList;
 import static io.onetable.delta.ScalaUtils.convertJavaMapToScala;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,20 +30,19 @@ import lombok.Builder;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.actions.Action;
 import org.apache.spark.sql.delta.actions.AddFile;
+import org.apache.spark.sql.delta.actions.RemoveFile;
 
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import io.onetable.exception.OneIOException;
 import io.onetable.model.schema.OneSchema;
 import io.onetable.model.stat.ColumnStat;
 import io.onetable.model.storage.OneDataFile;
 import io.onetable.model.storage.OneDataFilesDiff;
 import io.onetable.model.storage.OneFileGroup;
 import io.onetable.paths.PathUtils;
-import io.onetable.spi.extractor.DataFileIterator;
 
 @Builder
 public class DeltaDataFileUpdatesExtractor {
@@ -61,37 +59,50 @@ public class DeltaDataFileUpdatesExtractor {
 
   public Seq<Action> applySnapshot(
       DeltaLog deltaLog, List<OneFileGroup> partitionedDataFiles, OneSchema tableSchema) {
-    List<OneDataFile> currentDataFiles = new ArrayList<>();
-    try (DataFileIterator fileIterator =
-        deltaDataFileExtractor.iteratorWithoutStats(deltaLog.snapshot(), tableSchema)) {
-      fileIterator.forEachRemaining(currentDataFiles::add);
-      OneDataFilesDiff filesDiff =
-          OneDataFilesDiff.from(
-              partitionedDataFiles.stream()
-                  .flatMap(group -> group.getFiles().stream())
-                  .collect(Collectors.toList()),
-              currentDataFiles);
-      return applyDiff(filesDiff, tableSchema, deltaLog.dataPath().toString());
-    } catch (Exception e) {
-      throw new OneIOException("Failed to iterate through Delta data files", e);
-    }
+
+    // all files in the current delta snapshot are potential candidates for remove actions, i.e. if
+    // the file is not present in the new snapshot (addedFiles) then the file is considered removed
+    Map<String, Action> removedFiles =
+        deltaLog.snapshot().allFiles().collectAsList().stream()
+            .map(AddFile::remove)
+            .collect(Collectors.toMap(RemoveFile::path, file -> file));
+
+    Set<OneDataFile> addedFiles =
+        partitionedDataFiles.stream()
+            .flatMap(group -> group.getFiles().stream())
+            .map(
+                file -> {
+                  Action targetFileIfPresent = removedFiles.remove(file.getPhysicalPath());
+                  return targetFileIfPresent == null ? file : null;
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    return applyDiff(
+        addedFiles, removedFiles.values(), tableSchema, deltaLog.dataPath().toString());
   }
 
   public Seq<Action> applyDiff(
       OneDataFilesDiff oneDataFilesDiff, OneSchema tableSchema, String tableBasePath) {
-    Stream<Action> addActions =
-        oneDataFilesDiff.getFilesAdded().stream()
-            .flatMap(dFile -> createAddFileAction(dFile, tableSchema, tableBasePath));
-    Stream<Action> removeActions =
+    List<Action> removeActions =
         oneDataFilesDiff.getFilesRemoved().stream()
             .flatMap(dFile -> createAddFileAction(dFile, tableSchema, tableBasePath))
-            .map(AddFile::remove);
+            .map(AddFile::remove)
+            .collect(toList(oneDataFilesDiff.getFilesRemoved().size()));
+    return applyDiff(oneDataFilesDiff.getFilesAdded(), removeActions, tableSchema, tableBasePath);
+  }
+
+  private Seq<Action> applyDiff(
+      Set<OneDataFile> filesAdded,
+      Collection<Action> removeFileActions,
+      OneSchema tableSchema,
+      String tableBasePath) {
+    Stream<Action> addActions =
+        filesAdded.stream()
+            .flatMap(dFile -> createAddFileAction(dFile, tableSchema, tableBasePath));
+    int totalActions = filesAdded.size() + removeFileActions.size();
     List<Action> allActions =
-        Stream.concat(addActions, removeActions)
-            .collect(
-                toList(
-                    oneDataFilesDiff.getFilesAdded().size()
-                        + oneDataFilesDiff.getFilesRemoved().size()));
+        Stream.concat(addActions, removeFileActions.stream()).collect(toList(totalActions));
     return JavaConverters.asScalaBuffer(allActions).toSeq();
   }
 


### PR DESCRIPTION
Fixes #325 

The current code in the DeltaClient generates unnecessary objects when computing the file diff to find new and removed files. The process first converts all Delta Actions of the current delta log's snapshot to OneDataFiles, uses OneDataFiles to compute the diff, and then converts the resulting OneDataFiles collection back to Delta Action objects for writing. There is a round trip from Delta Action to OneDataFiles here. For large tables with thousands of Actions in a snapshot, this results in the creation of a large number of objects unnecessarily.

This change optimizes this process by skipping the unnecessary steps of converting delta actions from the previous snapshot into OneDataFiles and then back into delta actions. This optimizations does not change the behavior of the translation.

This change is already covered by existing tests for Delta conversion