### PR TITLE
Upgrade Delta Lake version:2.4 for deletion vector support

### DIFF
--- a/core/src/main/java/io/onetable/delta/DeltaClientUtils.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClientUtils.java
@@ -35,6 +35,8 @@ public class DeltaClientUtils {
         new SparkConf()
             .setAppName("onetableclient")
             .set("spark.serializer", KryoSerializer.class.getName())
+            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .set("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true");
     SparkSession.Builder builder = SparkSession.builder().config(sparkConf);
     conf.forEach(

--- a/core/src/main/java/io/onetable/delta/DeltaClientUtils.java
+++ b/core/src/main/java/io/onetable/delta/DeltaClientUtils.java
@@ -36,7 +36,9 @@ public class DeltaClientUtils {
             .setAppName("onetableclient")
             .set("spark.serializer", KryoSerializer.class.getName())
             .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-            .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .set(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .set("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true");
     SparkSession.Builder builder = SparkSession.builder().config(sparkConf);
     conf.forEach(

--- a/core/src/main/java/io/onetable/delta/DeltaDataFileUpdatesExtractor.java
+++ b/core/src/main/java/io/onetable/delta/DeltaDataFileUpdatesExtractor.java
@@ -115,6 +115,7 @@ public class DeltaDataFileUpdatesExtractor {
             dataFile.getLastModified(),
             true,
             getColumnStats(schema, dataFile.getRecordCount(), dataFile.getColumnStats()),
+            null,
             null));
   }
 

--- a/core/src/main/java/io/onetable/delta/DeltaSourceClient.java
+++ b/core/src/main/java/io/onetable/delta/DeltaSourceClient.java
@@ -107,8 +107,7 @@ public class DeltaSourceClient implements SourceClient<Long> {
     OneTable tableAtVersion = tableExtractor.table(deltaLog, tableName, versionNumber);
     // Client to call getCommitsBacklog and call this method.
     List<Action> actionsForVersion = getChangesState().getActionsForVersion(versionNumber);
-    Snapshot snapshotAtVersion =
-        deltaLog.getSnapshotAt(versionNumber, Option.empty(), Option.empty());
+    Snapshot snapshotAtVersion = deltaLog.getSnapshotAt(versionNumber, Option.empty());
     FileFormat fileFormat =
         actionsConverter.convertToOneTableFileFormat(
             snapshotAtVersion.metadata().format().provider());

--- a/core/src/main/java/io/onetable/delta/DeltaTableExtractor.java
+++ b/core/src/main/java/io/onetable/delta/DeltaTableExtractor.java
@@ -41,7 +41,7 @@ public class DeltaTableExtractor {
   private static final DeltaSchemaExtractor schemaExtractor = DeltaSchemaExtractor.getInstance();
 
   public OneTable table(DeltaLog deltaLog, String tableName, Long version) {
-    Snapshot snapshot = deltaLog.getSnapshotAt(version, Option.empty(), Option.empty());
+    Snapshot snapshot = deltaLog.getSnapshotAt(version, Option.empty());
     OneSchema schema = schemaExtractor.toOneSchema(snapshot.metadata().schema());
     List<OnePartitionField> partitionFields =
         DeltaPartitionExtractor.getInstance()

--- a/core/src/test/java/io/onetable/ITOneTableClient.java
+++ b/core/src/test/java/io/onetable/ITOneTableClient.java
@@ -676,7 +676,7 @@ public class ITOneTableClient {
       Assertions.assertEquals(1, snapshotCount);
       // assert that proper settings are enabled for delta log
       DeltaLog deltaLog = DeltaLog.forTable(sparkSession, table.getBasePath());
-      Assertions.assertTrue(deltaLog.enableExpiredLogCleanup());
+      Assertions.assertTrue(deltaLog.enableExpiredLogCleanup(deltaLog.snapshot().metadata()));
     }
   }
 

--- a/core/src/test/java/io/onetable/client/TestTableFormatClientFactory.java
+++ b/core/src/test/java/io/onetable/client/TestTableFormatClientFactory.java
@@ -45,7 +45,7 @@ public class TestTableFormatClientFactory {
     PerTableConfig perTableConfig =
         getPerTableConfig(Arrays.asList(TableFormat.DELTA), SyncMode.INCREMENTAL);
     Configuration conf = new Configuration();
-    conf.setStrings("spark.master", "local");
+    conf.set("spark.master", "local");
     tc.init(perTableConfig, conf);
     assertEquals(tc.getTableFormat(), TableFormat.DELTA);
   }

--- a/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
+++ b/core/src/test/java/io/onetable/delta/ITDeltaSourceClient.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
@@ -127,7 +128,7 @@ public class ITDeltaSourceClient {
             .config("spark.databricks.delta.schema.autoMerge.enabled", "true")
             .config("spark.sql.shuffle.partitions", "1")
             .config("spark.default.parallelism", "1")
-            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+            .config("spark.serializer", KryoSerializer.class.getName())
             .getOrCreate();
   }
 

--- a/core/src/test/java/io/onetable/delta/TestDeltaStatsExtractor.java
+++ b/core/src/test/java/io/onetable/delta/TestDeltaStatsExtractor.java
@@ -120,7 +120,7 @@ public class TestDeltaStatsExtractor {
 
     String stats =
         DeltaStatsExtractor.getInstance().convertStatsToDeltaFormat(schema, 50L, columnStats);
-    AddFile addFile = new AddFile("file://path/to/file", null, 0, 0, true, stats, null);
+    AddFile addFile = new AddFile("file://path/to/file", null, 0, 0, true, stats, null, null);
     DeltaStatsExtractor extractor = DeltaStatsExtractor.getInstance();
     List<ColumnStat> actual = extractor.getColumnStatsForFile(addFile, fields);
 
@@ -148,7 +148,7 @@ public class TestDeltaStatsExtractor {
     deltaStats.put("nullCount", nullValues);
     deltaStats.put("numRecords", 100);
     String stats = MAPPER.writeValueAsString(deltaStats);
-    AddFile addFile = new AddFile("file://path/to/file", null, 0, 0, true, stats, null);
+    AddFile addFile = new AddFile("file://path/to/file", null, 0, 0, true, stats, null, null);
     DeltaStatsExtractor extractor = DeltaStatsExtractor.getInstance();
     List<ColumnStat> actual = extractor.getColumnStatsForFile(addFile, fields);
 

--- a/core/src/test/java/io/onetable/delta/TestDeltaSync.java
+++ b/core/src/test/java/io/onetable/delta/TestDeltaSync.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.spark.sql.delta.GeneratedColumn;
 
-import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import io.delta.standalone.DeltaLog;
@@ -334,8 +333,7 @@ public class TestDeltaSync {
             .expr();
     org.apache.spark.sql.delta.DeltaLog deltaLog =
         org.apache.spark.sql.delta.DeltaLog.forTable(sparkSession, basePath.toString());
-    org.apache.spark.sql.delta.Snapshot snapshot =
-        deltaLog.getSnapshotAtInit(Option.empty()).snapshot();
+    org.apache.spark.sql.delta.Snapshot snapshot = deltaLog.getSnapshotAtInit().snapshot();
     Seq<org.apache.spark.sql.catalyst.expressions.Expression> expressionSeq =
         scala.collection.JavaConversions.asScalaBuffer(Collections.singletonList(expression));
     Seq<org.apache.spark.sql.catalyst.expressions.Expression> translatedExpression =
@@ -485,6 +483,8 @@ public class TestDeltaSync {
             .setAppName("testdeltasync")
             .set("spark.serializer", KryoSerializer.class.getName())
             .set("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true")
+            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .set("spark.master", "local[2]");
     return SparkSession.builder().config(sparkConf).getOrCreate();
   }

--- a/core/src/test/java/io/onetable/delta/TestDeltaSync.java
+++ b/core/src/test/java/io/onetable/delta/TestDeltaSync.java
@@ -484,7 +484,9 @@ public class TestDeltaSync {
             .set("spark.serializer", KryoSerializer.class.getName())
             .set("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true")
             .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-            .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .set(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .set("spark.master", "local[2]");
     return SparkSession.builder().config(sparkConf).getOrCreate();
   }

--- a/core/src/test/java/io/onetable/hudi/HudiTestUtil.java
+++ b/core/src/test/java/io/onetable/hudi/HudiTestUtil.java
@@ -129,7 +129,6 @@ public class HudiTestUtil {
         .set("spark.sql.shuffle.partitions", "1")
         .set("spark.default.parallelism", "1")
         .set("spark.sql.session.timeZone", "UTC")
-        .set("spark.sql.iceberg.handle-timestamp-without-timezone", "true")
         .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
         .set("spark.databricks.delta.retentionDurationCheck.enabled", "false")

--- a/hudi-support/extensions/pom.xml
+++ b/hudi-support/extensions/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hudi</groupId>
-            <artifactId>hudi-utilities_2.12</artifactId>
+            <artifactId>hudi-sync-common</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
+++ b/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
@@ -77,8 +77,6 @@ public class TestOneTableSyncTool {
     spark = SparkSession.builder().config(sparkConf).getOrCreate();
   }
 
-  @ParameterizedTest
-  @MethodSource(value = "testCases")
   public void testSync(String partitionPath) {
     String tableName = "table-" + UUID.randomUUID();
     String path = tempDir.toUri() + "/" + tableName;

--- a/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
+++ b/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
@@ -44,7 +44,9 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;

--- a/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
+++ b/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
@@ -77,6 +77,8 @@ public class TestOneTableSyncTool {
     spark = SparkSession.builder().config(sparkConf).getOrCreate();
   }
 
+  @ParameterizedTest
+  @MethodSource(value = "testCases")
   public void testSync(String partitionPath) {
     String tableName = "table-" + UUID.randomUUID();
     String path = tempDir.toUri() + "/" + tableName;

--- a/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
+++ b/hudi-support/extensions/src/test/java/io/onetable/hudi/sync/TestOneTableSyncTool.java
@@ -44,9 +44,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.keygen.constant.KeyGeneratorOptions;

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.hudi</groupId>
-                <artifactId>hudi-utilities_2.12</artifactId>
+                <artifactId>hudi-sync-common</artifactId>
                 <version>${hudi.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
         <lombok.version>1.18.30</lombok.version>
         <hudi.version>0.14.0</hudi.version>
         <parquet.version>1.12.2</parquet.version>
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.12</scala.version>
         <scala.version.prefix>2.12</scala.version.prefix>
-        <spark.version>3.2.1</spark.version>
-        <spark.version.prefix>3.2</spark.version.prefix>
+        <spark.version>3.4.2</spark.version>
+        <spark.version.prefix>3.4</spark.version.prefix>
         <iceberg.version>1.4.2</iceberg.version>
-        <delta.version>2.0.2</delta.version>
+        <delta.version>2.4.0</delta.version>
         <jackson.version>2.14.2</jackson.version>
         <test.plugin.version>2.22.2</test.plugin.version>
         <spotless.version>2.27.2</spotless.version>


### PR DESCRIPTION
Fixes #340 

Support for Deletion Vectors has been added in Delta Lake version 2.4. The upgrade also requires updating the spark runtime version to 3.4+

In addition to chaning the version of the dependencies, this change also incorporates all the backward incompatible changes in the Delta API.
1. getSnapshotAt change: it does not accept a optional timestamp (2nd method argument) anymore. This argument was not provided / used by XTable and can safely be ignored in all invocations.
2. addFile api change: It now requires information about DeleteVector as a parameter. As Deletion vectors writing is not supported in the current version of XTable, a null is provided to the addFile method call.
3. update transaction api change: It now requires an Catalyst Expression object, instead of a generic string object, to be linked to a update operation. This change replaces the string object used by XTable with a Literal-expression.
4. getSnapshot api change: It does not require a timestamp to initialize current snapshot anymore. This change removes the additional argument in the method invocation in XTable.
5. DeltaLog metadata change: The metadata is now available through the DeltaLog's snapshot instance, instead of being made available through the DeltaLog itself like in the older versions.
6. change in the update api: it now requires the user to choose if defaults need to be ignored. It seems that the defaults need to be ingored for operations like copy. By default, the value for ignore-defaults is false for most operations. Hence it is the choosen value in XTable also.
7. Update spark version requires catalog and sql extension configurations in the sessoin definition. This change adds these two configs wherever a spark instance is created for writing Delta Lake commits.